### PR TITLE
Move mass computation to pre-commit listener

### DIFF
--- a/massviewpoint/plugins/org.polarsys.capella.vp.mass.design/src/org/polarsys/capella/vp/mass/design/Activator.java
+++ b/massviewpoint/plugins/org.polarsys.capella.vp.mass.design/src/org/polarsys/capella/vp/mass/design/Activator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2006, 2015 Thales Global Services
+ * Copyright (c) 2006, 2020 Thales Global Services
  *   All rights reserved. This program and the accompanying materials
  *   are made available under the terms of the Eclipse Public License v1.0
  *   which accompanies this distribution, and is available at
@@ -7,70 +7,119 @@
  * 
  *   Contributors:
  *      Thales - initial API and implementation
+ *      OBEO - Code improvement
  ******************************************************************************/
 package org.polarsys.capella.vp.mass.design;
 
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
 
+import org.eclipse.emf.common.notify.Adapter;
+import org.eclipse.emf.common.util.EList;
+import org.eclipse.emf.transaction.TransactionalEditingDomain;
 import org.eclipse.sirius.business.api.componentization.ViewpointRegistry;
+import org.eclipse.sirius.business.api.session.Session;
+import org.eclipse.sirius.business.api.session.SessionManager;
 import org.eclipse.sirius.viewpoint.description.Viewpoint;
 import org.eclipse.ui.plugin.AbstractUIPlugin;
 import org.osgi.framework.BundleContext;
+import org.polarsys.capella.vp.mass.design.service.massListener.MassChangePreCommitListener;
+import org.polarsys.capella.vp.mass.design.service.massListener.MassSessionListener;
 
 /**
  * The activator class controls the plug-in life cycle
  */
 public class Activator extends AbstractUIPlugin {
-    // The plug-in ID
-    public static final String PLUGIN_ID = "org.polarsys.capella.vp.mass.design";
 
-    // The shared instance
-    private static Activator plugin;
+	MassSessionListener sessionListener;
 
-    private static Set<Viewpoint> viewpoints; 
+	// The plug-in ID
+	public static final String PLUGIN_ID = "org.polarsys.capella.vp.mass.design";
 
-    /**
-     * The constructor
-     */
-    public Activator() {
-    }
+	// The shared instance
+	private static Activator plugin;
 
-    /*
-     * (non-Javadoc)
-     * 
-     * @see org.eclipse.ui.plugin.AbstractUIPlugin#start(org.osgi.framework.BundleContext)
-     */
-    public void start(BundleContext context) throws Exception {
-      super.start(context);
-	  plugin = this;
-	  viewpoints = new HashSet<Viewpoint>();
-	  viewpoints.addAll(ViewpointRegistry.getInstance().registerFromPlugin(PLUGIN_ID + "/description/mass.odesign")); 
-    }
+	private static Set<Viewpoint> viewpoints;
 
-    /*
-     * (non-Javadoc)
-     * 
-     * @see org.eclipse.ui.plugin.AbstractUIPlugin#stop(org.osgi.framework.BundleContext)
-     */
-    public void stop(BundleContext context) throws Exception {
-	plugin = null;
-	if (viewpoints != null) {
-	    for (final Viewpoint viewpoint: viewpoints) {
-		ViewpointRegistry.getInstance().disposeFromPlugin(viewpoint);
-	    }
-	    viewpoints.clear();
-	    viewpoints = null; 
+	/**
+	 * The constructor
+	 */
+	public Activator() {
 	}
-	super.stop(context);
-    }
 
-    /**
-     * Returns the shared instance
-     * 
-     * @return the shared instance
-     */
-    public static Activator getDefault() {
-	return plugin;
-    }
+	/*
+	 * (non-Javadoc)
+	 * 
+	 * @see org.eclipse.ui.plugin.AbstractUIPlugin#start(org.osgi.framework.
+	 * BundleContext)
+	 */
+	public void start(BundleContext context) throws Exception {
+
+		super.start(context);
+		plugin = this;
+		viewpoints = new HashSet<Viewpoint>();
+		viewpoints.addAll(ViewpointRegistry.getInstance().registerFromPlugin(PLUGIN_ID + "/description/mass.odesign"));
+
+		// add a listener to the session manager so that the mass of the elements of the
+		// model can be calculated when a new session is opened
+		sessionListener = new MassSessionListener();
+		SessionManager.INSTANCE.addSessionsListener(sessionListener);
+
+		// for each session already opened, a pre-commit listener is installed so the
+		// mass of the elements of the model can be calculated after specific events
+		Collection<Session> sessions = SessionManager.INSTANCE.getSessions();
+		for (Session session : sessions) {
+			MassChangePreCommitListener massListener = new MassChangePreCommitListener();
+			TransactionalEditingDomain transDomain = session.getTransactionalEditingDomain();
+			if(transDomain != null) {
+				transDomain.addResourceSetListener(massListener);
+				// the listener and the session its attached to are saved in order to unregister
+				// him when the viewpoint is deselected
+				sessionListener.registerPreCommitListener(session, massListener);
+				sessionListener.computeMass(session);
+			}
+		}
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * 
+	 * @see
+	 * org.eclipse.ui.plugin.AbstractUIPlugin#stop(org.osgi.framework.BundleContext)
+	 */
+	public void stop(BundleContext context) throws Exception {
+		SessionManager.INSTANCE.removeSessionsListener(sessionListener);
+
+		// for each session opened, removes the pre-commit listener
+		Collection<Session> sessions = SessionManager.INSTANCE.getSessions();
+		for (Session session : sessions) {
+			EList<Adapter> adapters = session.getTransactionalEditingDomain().getResourceSet().eAdapters();
+			for (Adapter adapter : adapters) {
+				if (adapter instanceof MassChangePreCommitListener) {
+					session.getTransactionalEditingDomain()
+							.removeResourceSetListener((MassChangePreCommitListener) adapter);
+				}
+			}
+		}
+
+		plugin = null;
+		if (viewpoints != null) {
+			for (final Viewpoint viewpoint : viewpoints) {
+				ViewpointRegistry.getInstance().disposeFromPlugin(viewpoint);
+			}
+			viewpoints.clear();
+			viewpoints = null;
+		}
+		super.stop(context);
+	}
+
+	/**
+	 * Returns the shared instance
+	 * 
+	 * @return the shared instance
+	 */
+	public static Activator getDefault() {
+		return plugin;
+	}
 }

--- a/massviewpoint/plugins/org.polarsys.capella.vp.mass.design/src/org/polarsys/capella/vp/mass/design/Activator.java
+++ b/massviewpoint/plugins/org.polarsys.capella.vp.mass.design/src/org/polarsys/capella/vp/mass/design/Activator.java
@@ -7,7 +7,7 @@
  * 
  *   Contributors:
  *      Thales - initial API and implementation
- *      OBEO - Code improvement
+ *      Obeo - Code improvement
  ******************************************************************************/
 package org.polarsys.capella.vp.mass.design;
 

--- a/massviewpoint/plugins/org.polarsys.capella.vp.mass.design/src/org/polarsys/capella/vp/mass/design/service/MassOpenJavaService.java
+++ b/massviewpoint/plugins/org.polarsys.capella.vp.mass.design/src/org/polarsys/capella/vp/mass/design/service/MassOpenJavaService.java
@@ -7,6 +7,7 @@
  * 
  *   Contributors:
  *      Thales - initial API and implementation
+ *      Obeo - Code improvement
  ******************************************************************************/
 // Generated on 20.08.2015 at 11:04:11 CEST by Viewpoint DSL Generator V 0.1
 

--- a/massviewpoint/plugins/org.polarsys.capella.vp.mass.design/src/org/polarsys/capella/vp/mass/design/service/MassOpenJavaService.java
+++ b/massviewpoint/plugins/org.polarsys.capella.vp.mass.design/src/org/polarsys/capella/vp/mass/design/service/MassOpenJavaService.java
@@ -12,13 +12,9 @@
 
 package org.polarsys.capella.vp.mass.design.service;
 
-import java.util.ArrayList;
-import java.util.List;
 import org.eclipse.emf.common.util.BasicEList;
 import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.ecore.EObject;
-import org.eclipse.sirius.diagram.DDiagram;
-import org.eclipse.sirius.diagram.DDiagramElement;
 import org.eclipse.sirius.diagram.DSemanticDiagram;
 import org.eclipse.sirius.viewpoint.DSemanticDecorator;
 import org.polarsys.capella.core.data.cs.Part;

--- a/massviewpoint/plugins/org.polarsys.capella.vp.mass.design/src/org/polarsys/capella/vp/mass/design/service/edges/LinkPCDeployment_MassNode_Service.java
+++ b/massviewpoint/plugins/org.polarsys.capella.vp.mass.design/src/org/polarsys/capella/vp/mass/design/service/edges/LinkPCDeployment_MassNode_Service.java
@@ -10,11 +10,7 @@
 *****************************************************************************/
 package org.polarsys.capella.vp.mass.design.service.edges;
 
-import java.util.ArrayList;
-import java.util.List;
 import org.eclipse.emf.ecore.EObject;
-import org.eclipse.sirius.diagram.DDiagram;
-import org.eclipse.sirius.diagram.DDiagramElement;
 
 /**
  * <!-- begin-user-doc -->

--- a/massviewpoint/plugins/org.polarsys.capella.vp.mass.design/src/org/polarsys/capella/vp/mass/design/service/edges/LinkPCDeployment_MassNode_Service.java
+++ b/massviewpoint/plugins/org.polarsys.capella.vp.mass.design/src/org/polarsys/capella/vp/mass/design/service/edges/LinkPCDeployment_MassNode_Service.java
@@ -1,5 +1,5 @@
 /******************************************************************************
-* Copyright (c) 2006, 2016 Thales Global Services 
+* Copyright (c) 2006, 2020 Thales Global Services 
  * All rights reserved. This program and the accompanying materials 
  * are made available under the terms of the Eclipse Public License v1.0 
  * which accompanies this distribution, and is available at 
@@ -7,6 +7,7 @@
  * 
  * Contributors: 
  *    Thales - initial API and implementation
+ *    Obeo - code improvement
 *****************************************************************************/
 package org.polarsys.capella.vp.mass.design.service.edges;
 

--- a/massviewpoint/plugins/org.polarsys.capella.vp.mass.design/src/org/polarsys/capella/vp/mass/design/service/edges/LinkPC_MassNode_Service.java
+++ b/massviewpoint/plugins/org.polarsys.capella.vp.mass.design/src/org/polarsys/capella/vp/mass/design/service/edges/LinkPC_MassNode_Service.java
@@ -10,11 +10,7 @@
 *****************************************************************************/
 package org.polarsys.capella.vp.mass.design.service.edges;
 
-import java.util.ArrayList;
-import java.util.List;
 import org.eclipse.emf.ecore.EObject;
-import org.eclipse.sirius.diagram.DDiagram;
-import org.eclipse.sirius.diagram.DDiagramElement;
 
 /**
  * <!-- begin-user-doc -->

--- a/massviewpoint/plugins/org.polarsys.capella.vp.mass.design/src/org/polarsys/capella/vp/mass/design/service/edges/LinkPC_MassNode_Service.java
+++ b/massviewpoint/plugins/org.polarsys.capella.vp.mass.design/src/org/polarsys/capella/vp/mass/design/service/edges/LinkPC_MassNode_Service.java
@@ -1,5 +1,5 @@
 /******************************************************************************
-* Copyright (c) 2006, 2016 Thales Global Services 
+* Copyright (c) 2006, 2020 Thales Global Services 
  * All rights reserved. This program and the accompanying materials 
  * are made available under the terms of the Eclipse Public License v1.0 
  * which accompanies this distribution, and is available at 
@@ -7,6 +7,7 @@
  * 
  * Contributors: 
  *    Thales - initial API and implementation
+ *    Obeo - code improvement
 *****************************************************************************/
 package org.polarsys.capella.vp.mass.design.service.edges;
 

--- a/massviewpoint/plugins/org.polarsys.capella.vp.mass.design/src/org/polarsys/capella/vp/mass/design/service/massListener/MassChangePreCommitListener.java
+++ b/massviewpoint/plugins/org.polarsys.capella.vp.mass.design/src/org/polarsys/capella/vp/mass/design/service/massListener/MassChangePreCommitListener.java
@@ -6,7 +6,7 @@
  *   http://www.eclipse.org/legal/epl-v10.html
  * 
  *   Contributors:
- *      OBEO - initial API and implementation
+ *      Obeo - initial API and implementation
  ******************************************************************************/
 package org.polarsys.capella.vp.mass.design.service.massListener;
 

--- a/massviewpoint/plugins/org.polarsys.capella.vp.mass.design/src/org/polarsys/capella/vp/mass/design/service/massListener/MassChangePreCommitListener.java
+++ b/massviewpoint/plugins/org.polarsys.capella.vp.mass.design/src/org/polarsys/capella/vp/mass/design/service/massListener/MassChangePreCommitListener.java
@@ -1,0 +1,149 @@
+/*******************************************************************************
+ * Copyright (c) 2020 OBEO
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License v1.0
+ *   which accompanies this distribution, and is available at
+ *   http://www.eclipse.org/legal/epl-v10.html
+ * 
+ *   Contributors:
+ *      OBEO - initial API and implementation
+ ******************************************************************************/
+package org.polarsys.capella.vp.mass.design.service.massListener;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import org.eclipse.emf.common.command.Command;
+import org.eclipse.emf.common.command.CompoundCommand;
+import org.eclipse.emf.common.notify.Notification;
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.ecore.EReference;
+import org.eclipse.emf.transaction.NotificationFilter;
+import org.eclipse.emf.transaction.RecordingCommand;
+import org.eclipse.emf.transaction.ResourceSetChangeEvent;
+import org.eclipse.emf.transaction.ResourceSetListener;
+import org.eclipse.emf.transaction.RollbackException;
+import org.eclipse.emf.transaction.TransactionalEditingDomain;
+import org.polarsys.capella.common.data.modellingcore.AbstractType;
+import org.polarsys.capella.core.data.cs.Part;
+import org.polarsys.capella.core.data.cs.impl.PartImpl;
+import org.polarsys.capella.core.data.pa.PhysicalComponent;
+import org.polarsys.capella.core.data.pa.PhysicalComponentNature;
+import org.polarsys.capella.vp.mass.design.service.massSwitch.BottomUpComputeMassPaSwitch;
+import org.polarsys.capella.vp.mass.design.service.massSwitch.TopDownComputeMassPaSwitch;
+import org.polarsys.capella.vp.mass.mass.PartMass;
+import org.polarsys.capella.vp.mass.mass.impl.PartMassImpl;
+
+/**
+ * This listener is used to trigger the mass computation of the components
+ * before a change in the model is committed
+ */
+public class MassChangePreCommitListener implements ResourceSetListener {
+
+	@Override
+	public NotificationFilter getFilter() {
+
+		// the only notifications that should trigger a mass computation are:
+		// - add or remove a component of the model
+		// - change the mass of one of the elements of the model
+		return new NotificationFilter.Custom() {
+			@Override
+			public boolean matches(Notification notification) {
+				int eventType = notification.getEventType();
+				Object notifier = notification.getNotifier();
+				if (!notification.isTouch() && (eventType == Notification.REMOVE || eventType == Notification.ADD)) {
+					Object feature = notification.getFeature();
+					if (feature instanceof EReference) {
+						return ((EReference) feature).isContainment();
+					}
+				} else if (!notification.isTouch() && eventType == Notification.SET && notifier instanceof PartMass) {
+					return true;
+				}
+				return false;
+			}
+		};
+	}
+
+	@Override
+	public Command transactionAboutToCommit(ResourceSetChangeEvent event) throws RollbackException {
+		TransactionalEditingDomain domain = event.getEditingDomain();
+		List<Command> commands = new ArrayList<Command>();
+		Iterator<?> iter = event.getNotifications().iterator();
+
+		while (iter.hasNext()) {
+			Notification next = (Notification) iter.next();
+			switch (next.getEventType()) {
+
+			// if the mass of an element of the model changes, calculate the mass of its
+			// parents
+			case Notification.SET:
+				commands.add(new RecordingCommand(domain) {
+
+					@Override
+					protected void doExecute() {
+						PartMassImpl notifier = (PartMassImpl) next.getNotifier();
+						AbstractType physicalComponent = ((Part) notifier.eContainer()).getAbstractType();
+						BottomUpComputeMassPaSwitch bottomUpSwitch = new BottomUpComputeMassPaSwitch();
+						bottomUpSwitch.doSwitch(physicalComponent);
+					}
+				});
+				break;
+
+			// if an element is added or removed, calculate the mass of its parents
+			case Notification.ADD:
+			case Notification.REMOVE:
+				commands.add(new RecordingCommand(domain) {
+
+					@Override
+					protected void doExecute() {
+
+						EObject notifier = (EObject) next.getNotifier();
+
+						// When a behavior PC is removed, we cannot access the component it was deployed
+						// in. Hence why we need to re-calculate the whole model
+						Object oldValue = next.getOldValue();
+						if ((oldValue instanceof PhysicalComponent)
+								&& (((PhysicalComponent) oldValue)).getNature() == PhysicalComponentNature.BEHAVIOR) {
+							TopDownComputeMassPaSwitch topDownSwitch = new TopDownComputeMassPaSwitch();
+							topDownSwitch.doSwitch(notifier);
+							// If a partMass is deleted, we can access the component it was attached to
+							// through its abstract type
+						} else if (oldValue instanceof PartMassImpl) {
+							BottomUpComputeMassPaSwitch bottomUpSwitch = new BottomUpComputeMassPaSwitch();
+							bottomUpSwitch.doSwitch(((PartImpl) notifier).getAbstractType());
+						} else {
+							BottomUpComputeMassPaSwitch bottomUpSwitch = new BottomUpComputeMassPaSwitch();
+							bottomUpSwitch.doSwitch(notifier);
+						}
+					}
+				});
+				break;
+
+			default:
+				break;
+			}
+
+		}
+		return commands.isEmpty() ? null : new CompoundCommand(commands);
+	}
+
+	@Override
+	public boolean isPrecommitOnly() {
+		return true;
+	}
+
+	@Override
+	public void resourceSetChanged(ResourceSetChangeEvent event) {
+	}
+
+	@Override
+	public boolean isAggregatePrecommitListener() {
+		return false;
+	}
+
+	@Override
+	public boolean isPostcommitOnly() {
+		return false;
+	}
+
+}

--- a/massviewpoint/plugins/org.polarsys.capella.vp.mass.design/src/org/polarsys/capella/vp/mass/design/service/massListener/MassSessionListener.java
+++ b/massviewpoint/plugins/org.polarsys.capella.vp.mass.design/src/org/polarsys/capella/vp/mass/design/service/massListener/MassSessionListener.java
@@ -1,0 +1,147 @@
+/*******************************************************************************
+ * Copyright (c) 2020 OBEO
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License v1.0
+ *   which accompanies this distribution, and is available at
+ *   http://www.eclipse.org/legal/epl-v10.html
+ * 
+ *   Contributors:
+ *      OBEO - initial API and implementation
+ ******************************************************************************/
+package org.polarsys.capella.vp.mass.design.service.massListener;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import org.eclipse.emf.ecore.resource.Resource;
+import org.eclipse.emf.transaction.RecordingCommand;
+import org.eclipse.emf.transaction.TransactionalEditingDomain;
+import org.eclipse.sirius.business.api.session.Session;
+import org.eclipse.sirius.business.api.session.SessionManagerListener;
+import org.eclipse.sirius.viewpoint.description.Viewpoint;
+import org.polarsys.capella.core.data.capellamodeller.impl.ProjectImpl;
+import org.polarsys.capella.core.data.capellamodeller.impl.SystemEngineeringImpl;
+import org.polarsys.capella.core.data.capellamodeller.util.CapellamodellerResourceImpl;
+import org.polarsys.capella.core.data.pa.PhysicalComponentPkg;
+import org.polarsys.capella.core.data.pa.impl.PhysicalArchitectureImpl;
+import org.polarsys.capella.vp.mass.design.service.massSwitch.TopDownComputeMassPaSwitch;
+
+/**
+ * This session manager listener is used to install/remove a Mass Change
+ * PreCommit Listener to every new session and to start the mass computation of
+ * the elements of this session
+ *
+ */
+public class MassSessionListener implements SessionManagerListener {
+
+	Map<Session, MassChangePreCommitListener> sessionsMassPreCommitListener = new HashMap<>();
+
+	@Override
+	public void notifyAddSession(Session newSession) {
+		MassChangePreCommitListener massListener = new MassChangePreCommitListener();
+		newSession.getTransactionalEditingDomain().addResourceSetListener(massListener);
+		registerPreCommitListener(newSession, massListener);
+
+		computeMass(newSession);
+	}
+
+	@Override
+	public void notifyRemoveSession(Session removedSession) {
+	}
+
+	@Override
+	public void viewpointSelected(Viewpoint selectedSirius) {
+	}
+
+	@Override
+	public void viewpointDeselected(Viewpoint deselectedSirius) {
+
+		// for each session opened, remove the pre-commit listener
+		Set<Entry<Session, MassChangePreCommitListener>> setSessionsMassPreCommitListener = sessionsMassPreCommitListener
+				.entrySet();
+		Iterator<Entry<Session, MassChangePreCommitListener>> it = setSessionsMassPreCommitListener.iterator();
+		while (it.hasNext()) {
+			Entry<Session, MassChangePreCommitListener> e = it.next();
+			TransactionalEditingDomain transDomain = e.getKey().getTransactionalEditingDomain();
+			if(transDomain != null) {
+				transDomain.removeResourceSetListener(e.getValue());
+			}
+		}
+	}
+
+	@Override
+	public void notify(Session updated, int notification) {
+	}
+
+	/**
+	 * Saves a session and its mass listener
+	 * 
+	 * @param session
+	 * @param preCommit
+	 */
+	public void registerPreCommitListener(Session session, MassChangePreCommitListener preCommit) {
+		sessionsMassPreCommitListener.put(session, preCommit);
+	}
+
+	/**
+	 * Compute the mass of the elements of a session
+	 * 
+	 * @param the session
+	 */
+	public void computeMass(Session session) {
+		TransactionalEditingDomain domain = session.getTransactionalEditingDomain();
+		domain.getCommandStack().execute(new RecordingCommand(domain) {
+
+			@Override
+			protected void doExecute() {
+				TopDownComputeMassPaSwitch topDownSwitch = new TopDownComputeMassPaSwitch();
+
+				ArrayList<PhysicalComponentPkg> physicalComponentPkgs = retrievesPhysicalComponentPkgFromSession(session);
+				
+				for(PhysicalComponentPkg physicalComponentPkg : physicalComponentPkgs) {
+					topDownSwitch.doSwitch(physicalComponentPkg);
+				}
+			}
+
+		});
+
+	}
+
+	/**
+	 * Retrieves the root PhysicalComponentPkg of the Physical Architecture part of a capella model from its session
+	 * @param session
+	 * @return the PhysicalComponentPkg containing the components of the physical architecture of a capella model
+	 */
+	private ArrayList<PhysicalComponentPkg> retrievesPhysicalComponentPkgFromSession(Session session) {
+		Collection<Resource> resources = session.getSemanticResources();
+		ArrayList<PhysicalComponentPkg> physicalComponentPkg = new ArrayList<>();
+
+		resources.stream()
+			.filter(resource -> resource instanceof CapellamodellerResourceImpl)
+			.forEach((resource) -> {
+				resource.getContents().stream()
+					.filter(content -> content instanceof ProjectImpl)
+					.forEach((content) -> {
+						((ProjectImpl) content).getOwnedModelRoots().stream()
+							.filter(modelRoot -> modelRoot instanceof SystemEngineeringImpl)
+							.forEach((modelRoot) -> {
+								((SystemEngineeringImpl) modelRoot).getOwnedArchitectures().stream()
+								.filter(architecture -> architecture instanceof PhysicalArchitectureImpl)
+								.forEach((physicalArchitecture) -> {
+									physicalComponentPkg.add(((PhysicalArchitectureImpl) physicalArchitecture)
+										.getOwnedPhysicalComponentPkg()) ;
+									});
+							;
+						});
+				;
+			});
+			;
+		});
+		return physicalComponentPkg;
+	}
+
+}

--- a/massviewpoint/plugins/org.polarsys.capella.vp.mass.design/src/org/polarsys/capella/vp/mass/design/service/massListener/MassSessionListener.java
+++ b/massviewpoint/plugins/org.polarsys.capella.vp.mass.design/src/org/polarsys/capella/vp/mass/design/service/massListener/MassSessionListener.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2020 OBEO
+ * Copyright (c) 2020 Obeo
  *   All rights reserved. This program and the accompanying materials
  *   are made available under the terms of the Eclipse Public License v1.0
  *   which accompanies this distribution, and is available at
  *   http://www.eclipse.org/legal/epl-v10.html
  * 
  *   Contributors:
- *      OBEO - initial API and implementation
+ *      Obeo - initial API and implementation
  ******************************************************************************/
 package org.polarsys.capella.vp.mass.design.service.massListener;
 

--- a/massviewpoint/plugins/org.polarsys.capella.vp.mass.design/src/org/polarsys/capella/vp/mass/design/service/massSwitch/BottomUpComputeMassPaSwitch.java
+++ b/massviewpoint/plugins/org.polarsys.capella.vp.mass.design/src/org/polarsys/capella/vp/mass/design/service/massSwitch/BottomUpComputeMassPaSwitch.java
@@ -6,7 +6,7 @@
  *   http://www.eclipse.org/legal/epl-v10.html
  * 
  *   Contributors:
- *      OBEO - initial API and implementation
+ *      Obeo - initial API and implementation
  ******************************************************************************/
 package org.polarsys.capella.vp.mass.design.service.massSwitch;
 

--- a/massviewpoint/plugins/org.polarsys.capella.vp.mass.design/src/org/polarsys/capella/vp/mass/design/service/massSwitch/BottomUpComputeMassPaSwitch.java
+++ b/massviewpoint/plugins/org.polarsys.capella.vp.mass.design/src/org/polarsys/capella/vp/mass/design/service/massSwitch/BottomUpComputeMassPaSwitch.java
@@ -1,0 +1,52 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Thales Global Services
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License v1.0
+ *   which accompanies this distribution, and is available at
+ *   http://www.eclipse.org/legal/epl-v10.html
+ * 
+ *   Contributors:
+ *      OBEO - initial API and implementation
+ ******************************************************************************/
+package org.polarsys.capella.vp.mass.design.service.massSwitch;
+
+import org.eclipse.emf.common.util.EList;
+import org.polarsys.capella.common.data.modellingcore.AbstractTypedElement;
+import org.polarsys.capella.core.data.cs.Part;
+import org.polarsys.capella.core.data.pa.PhysicalComponent;
+import org.polarsys.capella.core.data.pa.PhysicalComponentNature;
+import org.polarsys.capella.core.data.pa.PhysicalComponentPkg;
+
+/**
+ * This switch is used to trigger the mass computation of a parent after one of
+ * its children's mass changed
+ */
+public class BottomUpComputeMassPaSwitch extends ComputeMassSwitch {
+
+	@Override
+	public Void casePhysicalComponent(PhysicalComponent physicalComponent) {
+		computeMass(physicalComponent);
+		
+		// The parent of a behavior component is not his container. The link is made
+		// through its deployingParts
+		if (physicalComponent.getNature() == PhysicalComponentNature.BEHAVIOR) {
+			EList<AbstractTypedElement> abstractTypedElements = physicalComponent.getAbstractTypedElements();
+
+			for (AbstractTypedElement part : abstractTypedElements) {
+				EList<Part> deployingParts = ((Part) part).getDeployingParts();
+				for (Part deployingPart : deployingParts) {
+					this.doSwitch(deployingPart.getAbstractType());
+				}
+			}
+		} else {
+			this.doSwitch(physicalComponent.eContainer());
+		}
+		return null;
+	}
+
+	@Override
+	public Void casePhysicalComponentPkg(PhysicalComponentPkg physicalComponentPkg) {
+		this.doSwitch(physicalComponentPkg.eContainer());
+		return null;
+	}
+}

--- a/massviewpoint/plugins/org.polarsys.capella.vp.mass.design/src/org/polarsys/capella/vp/mass/design/service/massSwitch/ComputeMassSwitch.java
+++ b/massviewpoint/plugins/org.polarsys.capella.vp.mass.design/src/org/polarsys/capella/vp/mass/design/service/massSwitch/ComputeMassSwitch.java
@@ -1,0 +1,43 @@
+/*******************************************************************************
+ * Copyright (c) 2020 OBEO
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License v1.0
+ *   which accompanies this distribution, and is available at
+ *   http://www.eclipse.org/legal/epl-v10.html
+ * 
+ *   Contributors:
+ *      OBEO - initial API and implementation
+ ******************************************************************************/
+package org.polarsys.capella.vp.mass.design.service.massSwitch;
+
+import org.eclipse.emf.common.util.EList;
+import org.polarsys.capella.common.data.modellingcore.AbstractTypedElement;
+import org.polarsys.capella.core.data.pa.PhysicalComponent;
+import org.polarsys.capella.core.data.pa.util.PaSwitch;
+import org.polarsys.capella.vp.mass.mass.impl.PartMassImpl;
+import org.polarsys.capella.vp.mass.services.MassCapellaService;
+import org.polarsys.kitalpha.emde.model.ElementExtension;
+
+public class ComputeMassSwitch extends PaSwitch<Void> {
+
+	/**
+	 * Check if a physical component has a mass. If he does, compute its mass.
+	 * 
+	 * @param physicalComponent
+	 */
+	public void computeMass(PhysicalComponent physicalComponent) {
+		EList<AbstractTypedElement> abstractTypedElements = physicalComponent.getAbstractTypedElements();
+
+		for (AbstractTypedElement part : abstractTypedElements) {
+			EList<ElementExtension> ownedExtensions = part.getOwnedExtensions();
+
+			for (ElementExtension extension : ownedExtensions) {
+
+				if (extension instanceof PartMassImpl) {
+					MassCapellaService maMassService = new MassCapellaService();
+					maMassService.computeMass(part);
+				}
+			}
+		}
+	}
+}

--- a/massviewpoint/plugins/org.polarsys.capella.vp.mass.design/src/org/polarsys/capella/vp/mass/design/service/massSwitch/ComputeMassSwitch.java
+++ b/massviewpoint/plugins/org.polarsys.capella.vp.mass.design/src/org/polarsys/capella/vp/mass/design/service/massSwitch/ComputeMassSwitch.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2020 OBEO
+ * Copyright (c) 2020 Obeo
  *   All rights reserved. This program and the accompanying materials
  *   are made available under the terms of the Eclipse Public License v1.0
  *   which accompanies this distribution, and is available at
  *   http://www.eclipse.org/legal/epl-v10.html
  * 
  *   Contributors:
- *      OBEO - initial API and implementation
+ *      Obeo - initial API and implementation
  ******************************************************************************/
 package org.polarsys.capella.vp.mass.design.service.massSwitch;
 

--- a/massviewpoint/plugins/org.polarsys.capella.vp.mass.design/src/org/polarsys/capella/vp/mass/design/service/massSwitch/TopDownComputeMassPaSwitch.java
+++ b/massviewpoint/plugins/org.polarsys.capella.vp.mass.design/src/org/polarsys/capella/vp/mass/design/service/massSwitch/TopDownComputeMassPaSwitch.java
@@ -1,0 +1,41 @@
+/*******************************************************************************
+ * Copyright (c) 2020 OBEO
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License v1.0
+ *   which accompanies this distribution, and is available at
+ *   http://www.eclipse.org/legal/epl-v10.html
+ * 
+ *   Contributors:
+ *      OBEO - initial API and implementation 
+ ******************************************************************************/
+package org.polarsys.capella.vp.mass.design.service.massSwitch;
+
+import org.eclipse.emf.common.util.EList;
+import org.polarsys.capella.common.data.modellingcore.AbstractTypedElement;
+import org.polarsys.capella.core.data.cs.Part;
+import org.polarsys.capella.core.data.pa.PhysicalComponent;
+import org.polarsys.capella.core.data.pa.PhysicalComponentPkg;
+
+/**
+ * This switch is used to trigger the mass computation of all the children of a
+ * component
+ */
+public class TopDownComputeMassPaSwitch extends ComputeMassSwitch {
+
+	@Override
+	public Void casePhysicalComponent(PhysicalComponent physicalComponent) {
+		computeMass(physicalComponent);
+		for (PhysicalComponent child : physicalComponent.getOwnedPhysicalComponents()) {
+			this.doSwitch(child);
+		}
+		return null;
+	}
+
+	@Override
+	public Void casePhysicalComponentPkg(PhysicalComponentPkg physicalComponentPkg) {
+		for (PhysicalComponent physicalComponent : physicalComponentPkg.getOwnedPhysicalComponents()) {
+			this.doSwitch(physicalComponent);
+		}
+		return null;
+	}
+}

--- a/massviewpoint/plugins/org.polarsys.capella.vp.mass.design/src/org/polarsys/capella/vp/mass/design/service/massSwitch/TopDownComputeMassPaSwitch.java
+++ b/massviewpoint/plugins/org.polarsys.capella.vp.mass.design/src/org/polarsys/capella/vp/mass/design/service/massSwitch/TopDownComputeMassPaSwitch.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2020 OBEO
+ * Copyright (c) 2020 Obeo
  *   All rights reserved. This program and the accompanying materials
  *   are made available under the terms of the Eclipse Public License v1.0
  *   which accompanies this distribution, and is available at
  *   http://www.eclipse.org/legal/epl-v10.html
  * 
  *   Contributors:
- *      OBEO - initial API and implementation 
+ *      Obeo - initial API and implementation 
  ******************************************************************************/
 package org.polarsys.capella.vp.mass.design.service.massSwitch;
 

--- a/massviewpoint/plugins/org.polarsys.capella.vp.mass.design/src/org/polarsys/capella/vp/mass/design/service/nodes/MassLevelHelper.java
+++ b/massviewpoint/plugins/org.polarsys.capella.vp.mass.design/src/org/polarsys/capella/vp/mass/design/service/nodes/MassLevelHelper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2006, 2016 Thales Global Services
+ * Copyright (c) 2006, 2020 Thales Global Services
  *   All rights reserved. This program and the accompanying materials
  *   are made available under the terms of the Eclipse Public License v1.0
  *   which accompanies this distribution, and is available at
@@ -7,6 +7,7 @@
  * 
  *   Contributors:
  *      Thales - initial API and implementation
+ *      OBEO - Code improvement
  ******************************************************************************/
 package org.polarsys.capella.vp.mass.design.service.nodes;
 
@@ -19,92 +20,80 @@ import org.polarsys.capella.vp.mass.services.MassCapellaService;
 import org.polarsys.kitalpha.emde.model.ElementExtension;
 
 public class MassLevelHelper {
-	
-	
+
 	private MassCapellaService maMassService = new MassCapellaService();
-	
-	
+
 	/**
-	 * Adapted Weight Services 
+	 * Adapted Weight Services
 	 */
-	
+
 	public int computeMass(EObject eObject) {
 		int m = maMassService.compute(eObject, maMassService.getVisitor(), Mass.class);
-		((PartMass)maMassService.getMassObject(eObject)).setCurrentMass(m);
+		((PartMass) maMassService.getMassObject(eObject)).setCurrentMass(m);
 		return m;
 	}
-	
-	public boolean isMassOverhead(EObject eObject, EObject view,
-			EObject container) {
-		if (eObject instanceof Mass){
+
+	public boolean isMassOverhead(EObject eObject, EObject view, EObject container) {
+		if (eObject instanceof Mass) {
 			return evaluateMassStatus(eObject, MassStatus.OVERHEAD);
 		}
-		
-		return computePartStatus((Part)eObject, view, container, MassStatus.OVERHEAD);
+
+		return computePartStatus((Part) eObject, view, container, MassStatus.OVERHEAD);
 	}
 
+	public boolean isMassSaturated(EObject eObject, EObject view, EObject container) {
 
-	public boolean isMassSaturated(EObject eObject, EObject view,
-			EObject container) {
-		
-		if (eObject instanceof Mass){
+		if (eObject instanceof Mass) {
 			return evaluateMassStatus(eObject, MassStatus.SATURATED);
 		}
-		
-		return computePartStatus((Part)eObject, view, container, MassStatus.SATURATED);
+
+		return computePartStatus((Part) eObject, view, container, MassStatus.SATURATED);
 	}
 
+	private boolean computePartStatus(Part part, EObject view, EObject container, MassStatus flag) {
 
-
-	private boolean computePartStatus(Part part, EObject view,
-			EObject container, MassStatus flag) {
-		
 		Mass currentPCMass = getMassExtension(part);
-		
+
 		if (currentPCMass != null)
 			return evaluateMassStatus(currentPCMass, flag);
-		
+
 		return false;
 	}
 
 	private Mass getMassExtension(Part part) {
-		
+
 		EList<ElementExtension> extensions = part.getOwnedExtensions();
-		
+
 		for (ElementExtension elementExtension : extensions) {
 			if (elementExtension instanceof Mass)
-				return (Mass)elementExtension;
+				return (Mass) elementExtension;
 		}
-		
+
 		return null;
 	}
-	
-	
-	private boolean evaluateMassStatus(EObject eObject, MassStatus flag){
-		final int current = maMassService.computeMass(eObject);
-		final int maxValue = ((Mass) eObject).getMaxValue();
-		
-		if (maxValue<= 0)
-		{
-			return false;
-		}
-		else
-		{
-			switch (flag) {
-			case OVERHEAD:
-				return current > maxValue;
 
-			case SATURATED:
-				return current != 0 && current == maxValue;
+	private boolean evaluateMassStatus(EObject eObject, MassStatus flag) {
+		if (eObject instanceof Mass) {
+			int current = ((PartMass) eObject).getCurrentMass();
+			final int maxValue = ((Mass) eObject).getMaxValue();
+
+			if (maxValue <= 0) {
+				return false;
+			} else {
+				switch (flag) {
+				case OVERHEAD:
+					return current > maxValue;
+
+				case SATURATED:
+					return current != 0 && current == maxValue;
+				}
 			}
 		}
-		
-		//May be a runtimeException
+		// May be a runtimeException
 		return false;
 	}
-	
+
 	private enum MassStatus {
-		OVERHEAD,
-		SATURATED
+		OVERHEAD, SATURATED
 	}
 }

--- a/massviewpoint/plugins/org.polarsys.capella.vp.mass.design/src/org/polarsys/capella/vp/mass/design/service/nodes/MassLevelHelper.java
+++ b/massviewpoint/plugins/org.polarsys.capella.vp.mass.design/src/org/polarsys/capella/vp/mass/design/service/nodes/MassLevelHelper.java
@@ -7,7 +7,7 @@
  * 
  *   Contributors:
  *      Thales - initial API and implementation
- *      OBEO - Code improvement
+ *      Obeo - Code improvement
  ******************************************************************************/
 package org.polarsys.capella.vp.mass.design.service.nodes;
 

--- a/massviewpoint/plugins/org.polarsys.capella.vp.mass/src/org/polarsys/capella/vp/mass/services/MassCapellaService.java
+++ b/massviewpoint/plugins/org.polarsys.capella.vp.mass/src/org/polarsys/capella/vp/mass/services/MassCapellaService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2006, 2015 Thales Global Services
+ * Copyright (c) 2006, 2020 Thales Global Services
  *   All rights reserved. This program and the accompanying materials
  *   are made available under the terms of the Eclipse Public License v1.0
  *   which accompanies this distribution, and is available at
@@ -7,11 +7,15 @@
  * 
  *   Contributors:
  *      Thales - initial API and implementation
+ *      Obeo - Code improvement
  ******************************************************************************/
 package org.polarsys.capella.vp.mass.services;
 
 import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.transaction.RecordingCommand;
+import org.eclipse.emf.transaction.TransactionalEditingDomain;
+import org.eclipse.emf.transaction.util.TransactionUtil;
 import org.polarsys.capella.core.data.cs.Part;
 import org.polarsys.capella.vp.mass.generic.IMassVisitor;
 import org.polarsys.capella.vp.mass.generic.MassGenericRootService;
@@ -68,7 +72,9 @@ public class MassCapellaService extends MassGenericRootService {
 	
 	public int computeMass(EObject eObject) {
 		int m = super.compute(eObject, getVisitor(), Mass.class);
-		((PartMass) getMassObject(eObject)).setCurrentMass(m);
+		if(m!=-1) {
+			((PartMass) getMassObject(eObject)).setCurrentMass(m);
+		}
 		return m;
 	}
 

--- a/massviewpoint/tests/org.polarsys.capella.vp.mass.ju/META-INF/MANIFEST.MF
+++ b/massviewpoint/tests/org.polarsys.capella.vp.mass.ju/META-INF/MANIFEST.MF
@@ -1,0 +1,14 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: Ju
+Bundle-SymbolicName: org.polarsys.capella.vp.mass.ju
+Bundle-Version: 1.4.0.qualifier
+Bundle-ClassPath: ju.jar,
+ capella-studio-1.4/plugins/org.eclipse.sirius_6.3.0.201910180815.jar
+Export-Package: org.polarsys.capella.vp.mass.ju
+Require-Bundle: org.polarsys.capella.core.libraries;bundle-version="1.4.0",
+ org.polarsys.capella.test.framework,
+ org.polarsys.capella.core.data.gen,
+ org.polarsys.capella.vp.mass
+Import-Package: org.polarsys.capella.vp.mass.mass.impl,
+ org.polarsys.capella.vp.mass.services

--- a/massviewpoint/tests/org.polarsys.capella.vp.mass.ju/model/MassProject/MassProject.afm
+++ b/massviewpoint/tests/org.polarsys.capella.vp.mass.ju/model/MassProject/MassProject.afm
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<metadata:Metadata xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:metadata="http://www.polarsys.org/kitalpha/ad/metadata/1.0.0" id="_isy7QF1jEeqBCMjfTVrmpQ">
+  <viewpointReferences id="_itjJMF1jEeqBCMjfTVrmpQ" vpId="org.polarsys.capella.core.viewpoint" version="1.4.0"/>
+  <viewpointReferences id="_o0_BgF1jEeqBCMjfTVrmpQ" vpId="org.polarsys.capella.vp.mass" version="1.4.0.qualifier"/>
+</metadata:Metadata>

--- a/massviewpoint/tests/org.polarsys.capella.vp.mass.ju/model/MassProject/MassProject.aird
+++ b/massviewpoint/tests/org.polarsys.capella.vp.mass.ju/model/MassProject/MassProject.aird
@@ -1,0 +1,342 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xmi:XMI xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:concern="http://www.eclipse.org/sirius/diagram/description/concern/1.1.0" xmlns:description="http://www.eclipse.org/sirius/description/1.1.0" xmlns:description_1="http://www.eclipse.org/sirius/diagram/description/1.1.0" xmlns:diagram="http://www.eclipse.org/sirius/diagram/1.1.0" xmlns:ecore="http://www.eclipse.org/emf/2002/Ecore" xmlns:filter="http://www.eclipse.org/sirius/diagram/description/filter/1.1.0" xmlns:mass="http://www.polarsys.org/capella/mass" xmlns:notation="http://www.eclipse.org/gmf/runtime/1.0.2/notation" xmlns:org.polarsys.capella.core.data.cs="http://www.polarsys.org/capella/core/cs/1.4.0" xmlns:org.polarsys.capella.core.data.pa="http://www.polarsys.org/capella/core/pa/1.4.0" xmlns:style="http://www.eclipse.org/sirius/diagram/description/style/1.1.0" xmlns:viewpoint="http://www.eclipse.org/sirius/1.1.0" xsi:schemaLocation="http://www.eclipse.org/sirius/diagram/description/concern/1.1.0 http://www.eclipse.org/sirius/diagram/1.1.0#//description/concern http://www.eclipse.org/sirius/description/1.1.0 http://www.eclipse.org/sirius/1.1.0#//description http://www.eclipse.org/sirius/diagram/description/1.1.0 http://www.eclipse.org/sirius/diagram/1.1.0#//description http://www.eclipse.org/sirius/diagram/description/filter/1.1.0 http://www.eclipse.org/sirius/diagram/1.1.0#//description/filter http://www.eclipse.org/sirius/diagram/description/style/1.1.0 http://www.eclipse.org/sirius/diagram/1.1.0#//description/style">
+  <viewpoint:DAnalysis uid="_is1XgF1jEeqBCMjfTVrmpQ" selectedViews="_iu8QUF1jEeqBCMjfTVrmpQ _ivfp8F1jEeqBCMjfTVrmpQ _i2JEgF1jEeqBCMjfTVrmpQ _i4ktcF1jEeqBCMjfTVrmpQ _i6bHkF1jEeqBCMjfTVrmpQ _i7I5QF1jEeqBCMjfTVrmpQ _i83-oF1jEeqBCMjfTVrmpQ _o1IygF1jEeqBCMjfTVrmpQ" version="14.3.0.201909031200">
+    <semanticResources>MassProject.afm</semanticResources>
+    <semanticResources>MassProject.melodymodeller</semanticResources>
+    <ownedViews xmi:type="viewpoint:DView" uid="_iu8QUF1jEeqBCMjfTVrmpQ">
+      <viewpoint xmi:type="description:Viewpoint" href="platform:/plugin/org.polarsys.kitalpha.ad.integration.sirius/description/ad.odesign#//@ownedViewpoints[name='ad']"/>
+    </ownedViews>
+    <ownedViews xmi:type="viewpoint:DView" uid="_ivfp8F1jEeqBCMjfTVrmpQ">
+      <viewpoint xmi:type="description:Viewpoint" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/EPBS.odesign#//@ownedViewpoints[name='EPBS%20architecture']"/>
+    </ownedViews>
+    <ownedViews xmi:type="viewpoint:DView" uid="_i2JEgF1jEeqBCMjfTVrmpQ">
+      <viewpoint xmi:type="description:Viewpoint" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']"/>
+      <ownedRepresentationDescriptors xmi:type="viewpoint:DRepresentationDescriptor" uid="_lFIroF1jEeqBCMjfTVrmpQ" name="[PAB] Structure" repPath="#_lDpd4F1jEeqBCMjfTVrmpQ" changeId="4d17f227-8094-4403-bf02-a21ec9b61897">
+        <eAnnotations xmi:type="description:DAnnotation" uid="_lSsmgF1jEeqBCMjfTVrmpQ" source="https://www.polarsys.org/capella/dannotation/DesactivatedFilters">
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_lStNkF1jEeqBCMjfTVrmpQ" key="hide.computed.component.exchanges.filter" value="true"/>
+          <details xmi:type="ecore:EStringToStringMapEntry" xmi:id="_lStNkV1jEeqBCMjfTVrmpQ" key="hide.computed.physical.links.filter" value="true"/>
+        </eAnnotations>
+        <description xmi:type="description_1:DiagramDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']"/>
+        <target xmi:type="org.polarsys.capella.core.data.pa:PhysicalComponentPkg" href="MassProject.melodymodeller#000ec20a-6206-477f-a742-6417048338e1"/>
+      </ownedRepresentationDescriptors>
+    </ownedViews>
+    <ownedViews xmi:type="viewpoint:DView" uid="_i4ktcF1jEeqBCMjfTVrmpQ">
+      <viewpoint xmi:type="description:Viewpoint" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/oa.odesign#//@ownedViewpoints[name='Operational%20Analysis']"/>
+    </ownedViews>
+    <ownedViews xmi:type="viewpoint:DView" uid="_i6bHkF1jEeqBCMjfTVrmpQ">
+      <viewpoint xmi:type="description:Viewpoint" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/logical.odesign#//@ownedViewpoints[name='Logical%20Architecture']"/>
+    </ownedViews>
+    <ownedViews xmi:type="viewpoint:DView" uid="_i7I5QF1jEeqBCMjfTVrmpQ">
+      <viewpoint xmi:type="description:Viewpoint" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/context.odesign#//@ownedViewpoints[name='System%20Analysis']"/>
+    </ownedViews>
+    <ownedViews xmi:type="viewpoint:DView" uid="_i83-oF1jEeqBCMjfTVrmpQ">
+      <viewpoint xmi:type="description:Viewpoint" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/common.odesign#//@ownedViewpoints[name='Common']"/>
+    </ownedViews>
+    <ownedViews xmi:type="viewpoint:DView" uid="_o1IygF1jEeqBCMjfTVrmpQ">
+      <viewpoint xmi:type="description:Viewpoint" href="platform:/plugin/org.polarsys.capella.vp.mass.design/description/mass.odesign#//@ownedViewpoints[name='Mass_ID']"/>
+    </ownedViews>
+  </viewpoint:DAnalysis>
+  <diagram:DSemanticDiagram uid="_lDpd4F1jEeqBCMjfTVrmpQ">
+    <ownedAnnotationEntries xmi:type="description:AnnotationEntry" uid="_lFDzIF1jEeqBCMjfTVrmpQ" source="DANNOTATION_CUSTOMIZATION_KEY">
+      <data xmi:type="diagram:ComputedStyleDescriptionRegistry" uid="_lFEaMF1jEeqBCMjfTVrmpQ"/>
+    </ownedAnnotationEntries>
+    <ownedAnnotationEntries xmi:type="description:AnnotationEntry" uid="_lJYScF1jEeqBCMjfTVrmpQ" source="GMF_DIAGRAMS">
+      <data xmi:type="notation:Diagram" xmi:id="_lJY5gF1jEeqBCMjfTVrmpQ" type="Sirius" element="_lDpd4F1jEeqBCMjfTVrmpQ" measurementUnit="Pixel">
+        <children xmi:type="notation:Node" xmi:id="_l5oqsF1jEeqBCMjfTVrmpQ" type="2002" element="_l3FtAF1jEeqBCMjfTVrmpQ">
+          <children xmi:type="notation:Node" xmi:id="_l5sVEF1jEeqBCMjfTVrmpQ" type="5006"/>
+          <children xmi:type="notation:Node" xmi:id="_l5tjMF1jEeqBCMjfTVrmpQ" type="7001">
+            <children xmi:type="notation:Node" xmi:id="_mpFxsF1jEeqBCMjfTVrmpQ" type="3008" element="_mo16EF1jEeqBCMjfTVrmpQ">
+              <children xmi:type="notation:Node" xmi:id="_mpGYwF1jEeqBCMjfTVrmpQ" type="5005"/>
+              <children xmi:type="notation:Node" xmi:id="_mpG_0F1jEeqBCMjfTVrmpQ" type="7002">
+                <styles xmi:type="notation:SortingStyle" xmi:id="_mpG_0V1jEeqBCMjfTVrmpQ"/>
+                <styles xmi:type="notation:FilteringStyle" xmi:id="_mpG_0l1jEeqBCMjfTVrmpQ"/>
+              </children>
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_mpFxsV1jEeqBCMjfTVrmpQ" fontName="Segoe UI" fontHeight="8"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_mpFxsl1jEeqBCMjfTVrmpQ" x="405" y="134" width="203" height="233"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_9YgRAF30EeqOkcuQb7nmWw" type="3008" element="_9X83YF30EeqOkcuQb7nmWw">
+              <children xmi:type="notation:Node" xmi:id="_9YlJgF30EeqOkcuQb7nmWw" type="5005"/>
+              <children xmi:type="notation:Node" xmi:id="_9YlwkF30EeqOkcuQb7nmWw" type="7002">
+                <children xmi:type="notation:Node" xmi:id="_5leckF36EeqOkcuQb7nmWw" type="3008" element="_5lNW0F36EeqOkcuQb7nmWw">
+                  <children xmi:type="notation:Node" xmi:id="_5lfDoF36EeqOkcuQb7nmWw" type="5005"/>
+                  <children xmi:type="notation:Node" xmi:id="_5lfDoV36EeqOkcuQb7nmWw" type="7002">
+                    <styles xmi:type="notation:SortingStyle" xmi:id="_5lfDol36EeqOkcuQb7nmWw"/>
+                    <styles xmi:type="notation:FilteringStyle" xmi:id="_5lfDo136EeqOkcuQb7nmWw"/>
+                  </children>
+                  <styles xmi:type="notation:ShapeStyle" xmi:id="_5leckV36EeqOkcuQb7nmWw" fontName="Segoe UI" fontHeight="8" italic="true"/>
+                  <layoutConstraint xmi:type="notation:Bounds" xmi:id="_5leckl36EeqOkcuQb7nmWw" x="55" y="84" width="193" height="133"/>
+                </children>
+                <styles xmi:type="notation:SortingStyle" xmi:id="_9YlwkV30EeqOkcuQb7nmWw"/>
+                <styles xmi:type="notation:FilteringStyle" xmi:id="_9Ylwkl30EeqOkcuQb7nmWw"/>
+              </children>
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_9YgRAV30EeqOkcuQb7nmWw" fontName="Segoe UI" fontHeight="8" italic="true"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_9YgRAl30EeqOkcuQb7nmWw" x="75" y="134" width="283" height="253"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_eRpF4F4kEeqOkcuQb7nmWw" type="3008" element="_eReGwF4kEeqOkcuQb7nmWw">
+              <children xmi:type="notation:Node" xmi:id="_eRps8F4kEeqOkcuQb7nmWw" type="5005"/>
+              <children xmi:type="notation:Node" xmi:id="_eRps8V4kEeqOkcuQb7nmWw" type="7002">
+                <styles xmi:type="notation:SortingStyle" xmi:id="_eRps8l4kEeqOkcuQb7nmWw"/>
+                <styles xmi:type="notation:FilteringStyle" xmi:id="_eRps814kEeqOkcuQb7nmWw"/>
+              </children>
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_eRpF4V4kEeqOkcuQb7nmWw" fontName="Segoe UI" fontHeight="8"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_eRpF4l4kEeqOkcuQb7nmWw" x="415" y="404"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_dx1J4F7TEeqDzIpsSmfT-g" type="3008" element="_dxGKEF7TEeqDzIpsSmfT-g">
+              <children xmi:type="notation:Node" xmi:id="_dx7QgF7TEeqDzIpsSmfT-g" type="5005"/>
+              <children xmi:type="notation:Node" xmi:id="_dx73kF7TEeqDzIpsSmfT-g" type="7002">
+                <styles xmi:type="notation:SortingStyle" xmi:id="_dx73kV7TEeqDzIpsSmfT-g"/>
+                <styles xmi:type="notation:FilteringStyle" xmi:id="_dx73kl7TEeqDzIpsSmfT-g"/>
+              </children>
+              <styles xmi:type="notation:ShapeStyle" xmi:id="_dx1J4V7TEeqDzIpsSmfT-g" fontName="Segoe UI" fontHeight="8" italic="true"/>
+              <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dx1J4l7TEeqDzIpsSmfT-g" x="76" y="414" width="282" height="73"/>
+            </children>
+            <styles xmi:type="notation:SortingStyle" xmi:id="_l5tjMV1jEeqBCMjfTVrmpQ"/>
+            <styles xmi:type="notation:FilteringStyle" xmi:id="_l5tjMl1jEeqBCMjfTVrmpQ"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_l5oqsV1jEeqBCMjfTVrmpQ" fontName="Segoe UI" fontHeight="8"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_l5oqsl1jEeqBCMjfTVrmpQ" x="440" y="150" width="733" height="733"/>
+        </children>
+        <children xmi:type="notation:Node" xmi:id="_p-LeMF1jEeqBCMjfTVrmpQ" type="2001" element="_p9zDsF1jEeqBCMjfTVrmpQ">
+          <children xmi:type="notation:Node" xmi:id="_p-MsUF1jEeqBCMjfTVrmpQ" type="5002">
+            <layoutConstraint xmi:type="notation:Location" xmi:id="_p-MsUV1jEeqBCMjfTVrmpQ" y="5"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_twOMcF1jEeqBCMjfTVrmpQ" type="3003" element="_twCmQV1jEeqBCMjfTVrmpQ">
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_twOMcV1jEeqBCMjfTVrmpQ" fontName="Segoe UI"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_twOMcl1jEeqBCMjfTVrmpQ"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_p-LeMV1jEeqBCMjfTVrmpQ" fontName="Segoe UI" fontHeight="8"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_p-LeMl1jEeqBCMjfTVrmpQ" x="1200" y="396" width="291" height="205"/>
+        </children>
+        <children xmi:type="notation:Node" xmi:id="_rwiMoF1jEeqBCMjfTVrmpQ" type="2001" element="_rwUKMl1jEeqBCMjfTVrmpQ">
+          <children xmi:type="notation:Node" xmi:id="_rwiMo11jEeqBCMjfTVrmpQ" type="5002">
+            <layoutConstraint xmi:type="notation:Location" xmi:id="_rwiMpF1jEeqBCMjfTVrmpQ" y="5"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_rwizsF1jEeqBCMjfTVrmpQ" type="3003" element="_rwUKM11jEeqBCMjfTVrmpQ">
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_rwizsV1jEeqBCMjfTVrmpQ" fontName="Segoe UI"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_rwizsl1jEeqBCMjfTVrmpQ"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_rwiMoV1jEeqBCMjfTVrmpQ" fontName="Segoe UI" fontHeight="8"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_rwiMol1jEeqBCMjfTVrmpQ" x="1200" y="170" width="281" height="171"/>
+        </children>
+        <children xmi:type="notation:Node" xmi:id="_AEDRQF31EeqOkcuQb7nmWw" type="2001" element="_ADuhIV31EeqOkcuQb7nmWw">
+          <children xmi:type="notation:Node" xmi:id="_AEEfYF31EeqOkcuQb7nmWw" type="5002">
+            <layoutConstraint xmi:type="notation:Location" xmi:id="_AEEfYV31EeqOkcuQb7nmWw" y="5"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_9JnRsF36EeqOkcuQb7nmWw" type="3003" element="_9JbEcV36EeqOkcuQb7nmWw">
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_9JnRsV36EeqOkcuQb7nmWw" fontName="Segoe UI"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_9JnRsl36EeqOkcuQb7nmWw"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_AEDRQV31EeqOkcuQb7nmWw" fontName="Segoe UI" fontHeight="8"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_AEDRQl31EeqOkcuQb7nmWw" x="270" y="250" width="90" height="60"/>
+        </children>
+        <children xmi:type="notation:Node" xmi:id="_7dP2gF36EeqOkcuQb7nmWw" type="2001" element="_7c_-5l36EeqOkcuQb7nmWw">
+          <children xmi:type="notation:Node" xmi:id="_7dQdkF36EeqOkcuQb7nmWw" type="5002">
+            <layoutConstraint xmi:type="notation:Location" xmi:id="_7dQdkV36EeqOkcuQb7nmWw" y="5"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_IlCzMF37EeqOkcuQb7nmWw" type="3003" element="_Ik1X0V37EeqOkcuQb7nmWw">
+            <styles xmi:type="notation:ShapeStyle" xmi:id="_IlCzMV37EeqOkcuQb7nmWw" fontName="Segoe UI"/>
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_IlCzMl37EeqOkcuQb7nmWw"/>
+          </children>
+          <styles xmi:type="notation:ShapeStyle" xmi:id="_7dP2gV36EeqOkcuQb7nmWw" fontName="Segoe UI" fontHeight="8"/>
+          <layoutConstraint xmi:type="notation:Bounds" xmi:id="_7dP2gl36EeqOkcuQb7nmWw" x="241" y="460" width="119" height="121"/>
+        </children>
+        <styles xmi:type="notation:DiagramStyle" xmi:id="_lJY5gV1jEeqBCMjfTVrmpQ"/>
+        <edges xmi:type="notation:Edge" xmi:id="_p-UBEF1jEeqBCMjfTVrmpQ" type="4001" element="_p98NoF1jEeqBCMjfTVrmpQ" source="_l5oqsF1jEeqBCMjfTVrmpQ" target="_p-LeMF1jEeqBCMjfTVrmpQ">
+          <children xmi:type="notation:Node" xmi:id="_p-VPMF1jEeqBCMjfTVrmpQ" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_p-VPMV1jEeqBCMjfTVrmpQ" y="-10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_p-WdUF1jEeqBCMjfTVrmpQ" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_p-WdUV1jEeqBCMjfTVrmpQ" y="10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_p-XEYF1jEeqBCMjfTVrmpQ" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_p-XEYV1jEeqBCMjfTVrmpQ" y="10"/>
+          </children>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_p-UoIF1jEeqBCMjfTVrmpQ"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_p-UoIV1jEeqBCMjfTVrmpQ" fontName="Segoe UI"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_p-UoIl1jEeqBCMjfTVrmpQ" points="[0, 0, 545, 135]$[-530, -132, 15, 3]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_p-hccF1jEeqBCMjfTVrmpQ" id="(0.5,0.33584131326949385)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_p-hccV1jEeqBCMjfTVrmpQ" id="(0.05154639175257732,0.07317073170731707)"/>
+        </edges>
+        <edges xmi:type="notation:Edge" xmi:id="_rwizs11jEeqBCMjfTVrmpQ" type="4001" element="_rwYbol1jEeqBCMjfTVrmpQ" source="_mpFxsF1jEeqBCMjfTVrmpQ" target="_rwiMoF1jEeqBCMjfTVrmpQ">
+          <children xmi:type="notation:Node" xmi:id="_rwjawF1jEeqBCMjfTVrmpQ" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_rwjawV1jEeqBCMjfTVrmpQ" x="9" y="-7"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_rwjawl1jEeqBCMjfTVrmpQ" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_rwjaw11jEeqBCMjfTVrmpQ" x="-8" y="6"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_rwjaxF1jEeqBCMjfTVrmpQ" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_rwjaxV1jEeqBCMjfTVrmpQ" x="-8" y="6"/>
+          </children>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_rwiztF1jEeqBCMjfTVrmpQ"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_rwiztV1jEeqBCMjfTVrmpQ" fontName="Segoe UI"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_rwiztl1jEeqBCMjfTVrmpQ" points="[76, -57, -164, 123]$[225, -169, -15, 11]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_rwjaxl1jEeqBCMjfTVrmpQ" id="(0.6243781094527363,0.3268398268398268)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_rwjax11jEeqBCMjfTVrmpQ" id="(0.05338078291814947,0.08771929824561403)"/>
+        </edges>
+        <edges xmi:type="notation:Edge" xmi:id="_AEJX4F31EeqOkcuQb7nmWw" type="4001" element="_AD114l31EeqOkcuQb7nmWw" source="_9YgRAF30EeqOkcuQb7nmWw" target="_AEDRQF31EeqOkcuQb7nmWw">
+          <children xmi:type="notation:Node" xmi:id="_AEKmAF31EeqOkcuQb7nmWw" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_AEKmAV31EeqOkcuQb7nmWw" x="4" y="9"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_AELNEF31EeqOkcuQb7nmWw" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_AELNEV31EeqOkcuQb7nmWw" x="-1" y="-9"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_AEL0IF31EeqOkcuQb7nmWw" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_AEL0IV31EeqOkcuQb7nmWw" x="-2" y="-10"/>
+          </children>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_AEJX4V31EeqOkcuQb7nmWw"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_AEJX4l31EeqOkcuQb7nmWw" fontName="Segoe UI"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_AEJX4131EeqOkcuQb7nmWw" points="[-140, -54, 175, 66]$[-300, -115, 15, 5]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_AEO3cF31EeqOkcuQb7nmWw" id="(0.5,0.5)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_AEO3cV31EeqOkcuQb7nmWw" id="(0.8333333333333334,0.75)"/>
+        </edges>
+        <edges xmi:type="notation:Edge" xmi:id="_7dREoF36EeqOkcuQb7nmWw" type="4001" element="_7dGFhl36EeqOkcuQb7nmWw" source="_5leckF36EeqOkcuQb7nmWw" target="_7dP2gF36EeqOkcuQb7nmWw">
+          <children xmi:type="notation:Node" xmi:id="_7dREpF36EeqOkcuQb7nmWw" type="6001">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_7dREpV36EeqOkcuQb7nmWw" x="-2" y="10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_7dREpl36EeqOkcuQb7nmWw" type="6002">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_7dREp136EeqOkcuQb7nmWw" x="3" y="-10"/>
+          </children>
+          <children xmi:type="notation:Node" xmi:id="_7dREqF36EeqOkcuQb7nmWw" type="6003">
+            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_7dREqV36EeqOkcuQb7nmWw" x="2" y="-9"/>
+          </children>
+          <styles xmi:type="notation:ConnectorStyle" xmi:id="_7dREoV36EeqOkcuQb7nmWw"/>
+          <styles xmi:type="notation:FontStyle" xmi:id="_7dREol36EeqOkcuQb7nmWw" fontName="Segoe UI"/>
+          <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_7dREo136EeqOkcuQb7nmWw" points="[-95, 6, 324, -24]$[-404, 28, 15, -2]"/>
+          <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_7dREql36EeqOkcuQb7nmWw" id="(0.5,0.5)"/>
+          <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_7dREq136EeqOkcuQb7nmWw" id="(0.12605042016806722,0.12396694214876033)"/>
+        </edges>
+      </data>
+    </ownedAnnotationEntries>
+    <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_l3FtAF1jEeqBCMjfTVrmpQ" name="PC 1" outgoingEdges="_p98NoF1jEeqBCMjfTVrmpQ">
+      <target xmi:type="org.polarsys.capella.core.data.cs:Part" href="MassProject.melodymodeller#627b6bf1-73e6-4e7e-af25-608742f03575"/>
+      <semanticElements xmi:type="org.polarsys.capella.core.data.cs:Part" href="MassProject.melodymodeller#627b6bf1-73e6-4e7e-af25-608742f03575"/>
+      <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_twD0YV1jEeqBCMjfTVrmpQ" borderSize="1" borderSizeComputationExpression="1" borderColor="123,105,79" backgroundStyle="GradientTopToBottom" backgroundColor="239,41,41" foregroundColor="255,255,255">
+        <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.polarsys.capella.vp.mass.design/description/mass.odesign#//@ownedViewpoints[name='Mass_ID']/@ownedRepresentationExtensions[name='Mass-PhysicalArchitectureBlank']/@layers[name='mass']/@containerMappings[name='PC_Mass_Container_Imported_CM']/@conditionnalStyles.1/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:ContainerMappingImport" href="platform:/plugin/org.polarsys.capella.vp.mass.design/description/mass.odesign#//@ownedViewpoints[name='Mass_ID']/@ownedRepresentationExtensions[name='Mass-PhysicalArchitectureBlank']/@layers[name='mass']/@containerMappings[name='PC_Mass_Container_Imported_CM']"/>
+      <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_mo16EF1jEeqBCMjfTVrmpQ" name="PC 1.1" outgoingEdges="_rwYbol1jEeqBCMjfTVrmpQ">
+        <target xmi:type="org.polarsys.capella.core.data.cs:Part" href="MassProject.melodymodeller#5031e230-e037-4178-8537-da1af39d62c3"/>
+        <semanticElements xmi:type="org.polarsys.capella.core.data.cs:Part" href="MassProject.melodymodeller#5031e230-e037-4178-8537-da1af39d62c3"/>
+        <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_mo2hIF1jEeqBCMjfTVrmpQ" borderSize="1" borderSizeComputationExpression="1" borderColor="123,105,79" backgroundStyle="GradientTopToBottom" backgroundColor="255,255,220" foregroundColor="255,252,183">
+          <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='PAB_PC']/@conditionnalStyles.2/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_1:ContainerMappingImport" href="platform:/plugin/org.polarsys.capella.vp.mass.design/description/mass.odesign#//@ownedViewpoints[name='Mass_ID']/@ownedRepresentationExtensions[name='Mass-PhysicalArchitectureBlank']/@layers[name='mass']/@containerMappings[name='PC_Mass_Container_Imported_CM']"/>
+      </ownedDiagramElements>
+      <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_9X83YF30EeqOkcuQb7nmWw" name="PC 1.2" outgoingEdges="_AD114l31EeqOkcuQb7nmWw">
+        <target xmi:type="org.polarsys.capella.core.data.cs:Part" href="MassProject.melodymodeller#695c334e-b5eb-4bc2-9ab7-cfe541cb4feb"/>
+        <semanticElements xmi:type="org.polarsys.capella.core.data.cs:Part" href="MassProject.melodymodeller#695c334e-b5eb-4bc2-9ab7-cfe541cb4feb"/>
+        <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_9Jc5ol36EeqOkcuQb7nmWw" borderSize="1" borderSizeComputationExpression="1" borderColor="74,74,151" backgroundStyle="GradientTopToBottom" backgroundColor="239,41,41" foregroundColor="255,255,255">
+          <labelFormat>italic</labelFormat>
+          <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.polarsys.capella.vp.mass.design/description/mass.odesign#//@ownedViewpoints[name='Mass_ID']/@ownedRepresentationExtensions[name='Mass-PhysicalArchitectureBlank']/@layers[name='mass']/@containerMappings[name='PC_Deployment_Mass_Container_Imported_CM']/@conditionnalStyles.1/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_1:ContainerMappingImport" href="platform:/plugin/org.polarsys.capella.vp.mass.design/description/mass.odesign#//@ownedViewpoints[name='Mass_ID']/@ownedRepresentationExtensions[name='Mass-PhysicalArchitectureBlank']/@layers[name='mass']/@containerMappings[name='PC_Deployment_Mass_Container_Imported_CM']"/>
+        <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_5lNW0F36EeqOkcuQb7nmWw" name="PC 1.2.1" outgoingEdges="_7dGFhl36EeqOkcuQb7nmWw">
+          <target xmi:type="org.polarsys.capella.core.data.cs:Part" href="MassProject.melodymodeller#a9f25446-4966-4b88-92fe-0ea1de344365"/>
+          <semanticElements xmi:type="org.polarsys.capella.core.data.cs:Part" href="MassProject.melodymodeller#a9f25446-4966-4b88-92fe-0ea1de344365"/>
+          <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_Ik5CM137EeqOkcuQb7nmWw" borderSize="1" borderSizeComputationExpression="1" borderColor="74,74,151" backgroundStyle="GradientTopToBottom" backgroundColor="195,230,255" foregroundColor="150,177,218">
+            <labelFormat>italic</labelFormat>
+            <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='PAB_Deployment']/@style"/>
+          </ownedStyle>
+          <actualMapping xmi:type="description_1:ContainerMappingImport" href="platform:/plugin/org.polarsys.capella.vp.mass.design/description/mass.odesign#//@ownedViewpoints[name='Mass_ID']/@ownedRepresentationExtensions[name='Mass-PhysicalArchitectureBlank']/@layers[name='mass']/@containerMappings[name='PC_Deployment_Mass_Container_Imported_CM']"/>
+        </ownedDiagramElements>
+      </ownedDiagramElements>
+      <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_eReGwF4kEeqOkcuQb7nmWw" name="PC 1.3">
+        <target xmi:type="org.polarsys.capella.core.data.cs:Part" href="MassProject.melodymodeller#28a096c4-0e5f-4c34-b027-1edd2ffeeb61"/>
+        <semanticElements xmi:type="org.polarsys.capella.core.data.cs:Part" href="MassProject.melodymodeller#28a096c4-0e5f-4c34-b027-1edd2ffeeb61"/>
+        <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_eReGwV4kEeqOkcuQb7nmWw" borderSize="1" borderSizeComputationExpression="1" borderColor="123,105,79" backgroundStyle="GradientTopToBottom" backgroundColor="255,255,220" foregroundColor="255,252,183">
+          <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='PAB_PC']/@conditionnalStyles.2/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_1:ContainerMappingImport" href="platform:/plugin/org.polarsys.capella.vp.mass.design/description/mass.odesign#//@ownedViewpoints[name='Mass_ID']/@ownedRepresentationExtensions[name='Mass-PhysicalArchitectureBlank']/@layers[name='mass']/@containerMappings[name='PC_Mass_Container_Imported_CM']"/>
+      </ownedDiagramElements>
+      <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_dxGKEF7TEeqDzIpsSmfT-g" name="PC 1.4">
+        <target xmi:type="org.polarsys.capella.core.data.cs:Part" href="MassProject.melodymodeller#c97ec17c-d34c-4d89-b50c-8b458ba1b177"/>
+        <semanticElements xmi:type="org.polarsys.capella.core.data.cs:Part" href="MassProject.melodymodeller#c97ec17c-d34c-4d89-b50c-8b458ba1b177"/>
+        <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_dxHYMF7TEeqDzIpsSmfT-g" borderSize="1" borderSizeComputationExpression="1" borderColor="74,74,151" backgroundStyle="GradientTopToBottom" backgroundColor="195,230,255" foregroundColor="150,177,218">
+          <labelFormat>italic</labelFormat>
+          <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer/@containerMappings[name='PAB_Deployment']/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_1:ContainerMappingImport" href="platform:/plugin/org.polarsys.capella.vp.mass.design/description/mass.odesign#//@ownedViewpoints[name='Mass_ID']/@ownedRepresentationExtensions[name='Mass-PhysicalArchitectureBlank']/@layers[name='mass']/@containerMappings[name='PC_Deployment_Mass_Container_Imported_CM']"/>
+      </ownedDiagramElements>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DNode" uid="_p9zDsF1jEeqBCMjfTVrmpQ" name="85 - Max: 50" incomingEdges="_p98NoF1jEeqBCMjfTVrmpQ" width="3" height="3" resizeKind="NSEW">
+      <target xmi:type="mass:PartMass" href="MassProject.melodymodeller#_p9sWAF1jEeqBCMjfTVrmpQ"/>
+      <semanticElements xmi:type="mass:PartMass" href="MassProject.melodymodeller#_p9sWAF1jEeqBCMjfTVrmpQ"/>
+      <ownedStyle xmi:type="diagram:Square" uid="_twCmQV1jEeqBCMjfTVrmpQ" borderSize="1" borderSizeComputationExpression="1" borderColor="252,175,62" labelPosition="node" color="246,139,139">
+        <description xmi:type="style:SquareDescription" href="platform:/plugin/org.polarsys.capella.vp.mass.design/description/mass.odesign#//@ownedViewpoints[name='Mass_ID']/@ownedRepresentationExtensions[name='Mass-PhysicalArchitectureBlank']/@layers[name='mass']/@nodeMappings[name='PC_Mass_Label_NM']/@conditionnalStyles.1/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.polarsys.capella.vp.mass.design/description/mass.odesign#//@ownedViewpoints[name='Mass_ID']/@ownedRepresentationExtensions[name='Mass-PhysicalArchitectureBlank']/@layers[name='mass']/@nodeMappings[name='PC_Mass_Label_NM']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DNode" uid="_rwUKMl1jEeqBCMjfTVrmpQ" name="50 - Max: 100" incomingEdges="_rwYbol1jEeqBCMjfTVrmpQ" width="3" height="3" resizeKind="NSEW">
+      <target xmi:type="mass:PartMass" href="MassProject.melodymodeller#_rwQf0F1jEeqBCMjfTVrmpQ"/>
+      <semanticElements xmi:type="mass:PartMass" href="MassProject.melodymodeller#_rwQf0F1jEeqBCMjfTVrmpQ"/>
+      <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
+      <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
+      <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
+      <ownedStyle xmi:type="diagram:Square" uid="_rwUKM11jEeqBCMjfTVrmpQ" borderSize="1" borderSizeComputationExpression="1" borderColor="252,175,62" labelPosition="node" color="255,245,181">
+        <description xmi:type="style:SquareDescription" href="platform:/plugin/org.polarsys.capella.vp.mass.design/description/mass.odesign#//@ownedViewpoints[name='Mass_ID']/@ownedRepresentationExtensions[name='Mass-PhysicalArchitectureBlank']/@layers[name='mass']/@nodeMappings[name='PC_Mass_Label_NM']/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.polarsys.capella.vp.mass.design/description/mass.odesign#//@ownedViewpoints[name='Mass_ID']/@ownedRepresentationExtensions[name='Mass-PhysicalArchitectureBlank']/@layers[name='mass']/@nodeMappings[name='PC_Mass_Label_NM']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DNode" uid="_ADuhIV31EeqOkcuQb7nmWw" name="15 - Max: 10" incomingEdges="_AD114l31EeqOkcuQb7nmWw" width="3" height="3" resizeKind="NSEW">
+      <target xmi:type="mass:PartMass" href="MassProject.melodymodeller#_ADoagF31EeqOkcuQb7nmWw"/>
+      <semanticElements xmi:type="mass:PartMass" href="MassProject.melodymodeller#_ADoagF31EeqOkcuQb7nmWw"/>
+      <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
+      <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
+      <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
+      <ownedStyle xmi:type="diagram:Square" uid="_9JbEcV36EeqOkcuQb7nmWw" borderSize="1" borderSizeComputationExpression="1" borderColor="252,175,62" labelPosition="node" color="246,139,139">
+        <description xmi:type="style:SquareDescription" href="platform:/plugin/org.polarsys.capella.vp.mass.design/description/mass.odesign#//@ownedViewpoints[name='Mass_ID']/@ownedRepresentationExtensions[name='Mass-PhysicalArchitectureBlank']/@layers[name='mass']/@nodeMappings[name='PC_Mass_Label_NM']/@conditionnalStyles.1/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.polarsys.capella.vp.mass.design/description/mass.odesign#//@ownedViewpoints[name='Mass_ID']/@ownedRepresentationExtensions[name='Mass-PhysicalArchitectureBlank']/@layers[name='mass']/@nodeMappings[name='PC_Mass_Label_NM']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DNode" uid="_7c_-5l36EeqOkcuQb7nmWw" name="5 - Max: 10" incomingEdges="_7dGFhl36EeqOkcuQb7nmWw" width="3" height="3" resizeKind="NSEW">
+      <target xmi:type="mass:PartMass" href="MassProject.melodymodeller#_7c7GYF36EeqOkcuQb7nmWw"/>
+      <semanticElements xmi:type="mass:PartMass" href="MassProject.melodymodeller#_7c7GYF36EeqOkcuQb7nmWw"/>
+      <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
+      <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
+      <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
+      <ownedStyle xmi:type="diagram:Square" uid="_Ik1X0V37EeqOkcuQb7nmWw" borderSize="1" borderSizeComputationExpression="1" borderColor="252,175,62" labelPosition="node" color="255,245,181">
+        <description xmi:type="style:SquareDescription" href="platform:/plugin/org.polarsys.capella.vp.mass.design/description/mass.odesign#//@ownedViewpoints[name='Mass_ID']/@ownedRepresentationExtensions[name='Mass-PhysicalArchitectureBlank']/@layers[name='mass']/@nodeMappings[name='PC_Mass_Label_NM']/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.polarsys.capella.vp.mass.design/description/mass.odesign#//@ownedViewpoints[name='Mass_ID']/@ownedRepresentationExtensions[name='Mass-PhysicalArchitectureBlank']/@layers[name='mass']/@nodeMappings[name='PC_Mass_Label_NM']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_p98NoF1jEeqBCMjfTVrmpQ" sourceNode="_l3FtAF1jEeqBCMjfTVrmpQ" targetNode="_p9zDsF1jEeqBCMjfTVrmpQ">
+      <target xmi:type="org.polarsys.capella.core.data.cs:Part" href="MassProject.melodymodeller#627b6bf1-73e6-4e7e-af25-608742f03575"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_twHewF1jEeqBCMjfTVrmpQ" lineStyle="dash" targetArrow="NoDecoration" size="0" strokeColor="156,12,12">
+        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.polarsys.capella.vp.mass.design/description/mass.odesign#//@ownedViewpoints[name='Mass_ID']/@ownedRepresentationExtensions[name='Mass-PhysicalArchitectureBlank']/@layers[name='mass']/@edgeMappings[name='LinkPC_MassNode_EM']/@conditionnalStyles.1/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.polarsys.capella.vp.mass.design/description/mass.odesign#//@ownedViewpoints[name='Mass_ID']/@ownedRepresentationExtensions[name='Mass-PhysicalArchitectureBlank']/@layers[name='mass']/@edgeMappings[name='LinkPC_MassNode_EM']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_rwYbol1jEeqBCMjfTVrmpQ" sourceNode="_mo16EF1jEeqBCMjfTVrmpQ" targetNode="_rwUKMl1jEeqBCMjfTVrmpQ">
+      <target xmi:type="org.polarsys.capella.core.data.cs:Part" href="MassProject.melodymodeller#5031e230-e037-4178-8537-da1af39d62c3"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_rwZpwF1jEeqBCMjfTVrmpQ" lineStyle="dash" targetArrow="NoDecoration" size="0" strokeColor="0,0,0">
+        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.polarsys.capella.vp.mass.design/description/mass.odesign#//@ownedViewpoints[name='Mass_ID']/@ownedRepresentationExtensions[name='Mass-PhysicalArchitectureBlank']/@layers[name='mass']/@edgeMappings[name='LinkPC_MassNode_EM']/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.polarsys.capella.vp.mass.design/description/mass.odesign#//@ownedViewpoints[name='Mass_ID']/@ownedRepresentationExtensions[name='Mass-PhysicalArchitectureBlank']/@layers[name='mass']/@edgeMappings[name='LinkPC_MassNode_EM']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_AD114l31EeqOkcuQb7nmWw" sourceNode="_9X83YF30EeqOkcuQb7nmWw" targetNode="_ADuhIV31EeqOkcuQb7nmWw">
+      <target xmi:type="org.polarsys.capella.core.data.cs:Part" href="MassProject.melodymodeller#695c334e-b5eb-4bc2-9ab7-cfe541cb4feb"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_9JgkBF36EeqOkcuQb7nmWw" lineStyle="dash" targetArrow="NoDecoration" size="0" strokeColor="156,12,12">
+        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.polarsys.capella.vp.mass.design/description/mass.odesign#//@ownedViewpoints[name='Mass_ID']/@ownedRepresentationExtensions[name='Mass-PhysicalArchitectureBlank']/@layers[name='mass']/@edgeMappings[name='LinkPCDeployment_MassNode_EM']/@conditionnalStyles.1/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.polarsys.capella.vp.mass.design/description/mass.odesign#//@ownedViewpoints[name='Mass_ID']/@ownedRepresentationExtensions[name='Mass-PhysicalArchitectureBlank']/@layers[name='mass']/@edgeMappings[name='LinkPCDeployment_MassNode_EM']"/>
+    </ownedDiagramElements>
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_7dGFhl36EeqOkcuQb7nmWw" sourceNode="_5lNW0F36EeqOkcuQb7nmWw" targetNode="_7c_-5l36EeqOkcuQb7nmWw">
+      <target xmi:type="org.polarsys.capella.core.data.cs:Part" href="MassProject.melodymodeller#a9f25446-4966-4b88-92fe-0ea1de344365"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_Ik8sll37EeqOkcuQb7nmWw" lineStyle="dash" targetArrow="NoDecoration" size="0" strokeColor="0,0,0">
+        <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.polarsys.capella.vp.mass.design/description/mass.odesign#//@ownedViewpoints[name='Mass_ID']/@ownedRepresentationExtensions[name='Mass-PhysicalArchitectureBlank']/@layers[name='mass']/@edgeMappings[name='LinkPCDeployment_MassNode_EM']/@style"/>
+      </ownedStyle>
+      <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.polarsys.capella.vp.mass.design/description/mass.odesign#//@ownedViewpoints[name='Mass_ID']/@ownedRepresentationExtensions[name='Mass-PhysicalArchitectureBlank']/@layers[name='mass']/@edgeMappings[name='LinkPCDeployment_MassNode_EM']"/>
+    </ownedDiagramElements>
+    <description xmi:type="description_1:DiagramDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']"/>
+    <currentConcern xmi:type="concern:ConcernDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@concerns/@ownedConcernDescriptions.0"/>
+    <activatedFilters xmi:type="filter:CompositeFilterDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@filters[name='hide.simplified.diagram.based.component.exchanges.filter']"/>
+    <activatedFilters xmi:type="filter:CompositeFilterDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@filters[name='hide.simplified.group.of.component.exchanges.filter']"/>
+    <activatedFilters xmi:type="filter:CompositeFilterDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@filters[name='hide.simplified.oriented.grouped.component.exchanges.filter']"/>
+    <activatedFilters xmi:type="filter:CompositeFilterDescription" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@filters[name='hide.sequencing.information.filter']"/>
+    <activatedFilters xmi:type="filter:CompositeFilterDescription" href="platform:/plugin/org.polarsys.kitalpha.ad.integration.sirius/description/ad.odesign#//@ownedViewpoints[name='ad']/@ownedRepresentations[name='AD%20diagram']/@filters[name='ModelExtensionFilter']"/>
+    <filterVariableHistory xmi:type="diagram:FilterVariableHistory" uid="_lDzO4F1jEeqBCMjfTVrmpQ"/>
+    <activatedLayers xmi:type="description_1:Layer" href="platform:/plugin/org.polarsys.capella.core.sirius.analysis/description/physical.odesign#//@ownedViewpoints[name='Physical%20Architecture']/@ownedRepresentations[name='Physical%20Architecture%20Blank']/@defaultLayer"/>
+    <activatedLayers xmi:type="description_1:AdditionalLayer" href="platform:/plugin/org.polarsys.capella.vp.mass.design/description/mass.odesign#//@ownedViewpoints[name='Mass_ID']/@ownedRepresentationExtensions[name='Mass-PhysicalArchitectureBlank']/@layers[name='mass']"/>
+    <target xmi:type="org.polarsys.capella.core.data.pa:PhysicalComponentPkg" href="MassProject.melodymodeller#000ec20a-6206-477f-a742-6417048338e1"/>
+  </diagram:DSemanticDiagram>
+</xmi:XMI>

--- a/massviewpoint/tests/org.polarsys.capella.vp.mass.ju/model/MassProject/MassProject.melodymodeller
+++ b/massviewpoint/tests/org.polarsys.capella.vp.mass.ju/model/MassProject/MassProject.melodymodeller
@@ -1,0 +1,319 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--Capella_Version_1.4.0-->
+<org.polarsys.capella.core.data.capellamodeller:Project xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:libraries="http://www.polarsys.org/capella/common/libraries/1.4.0"
+    xmlns:mass="http://www.polarsys.org/capella/mass" xmlns:org.polarsys.capella.core.data.capellacommon="http://www.polarsys.org/capella/core/common/1.4.0"
+    xmlns:org.polarsys.capella.core.data.capellacore="http://www.polarsys.org/capella/core/core/1.4.0"
+    xmlns:org.polarsys.capella.core.data.capellamodeller="http://www.polarsys.org/capella/core/modeller/1.4.0"
+    xmlns:org.polarsys.capella.core.data.cs="http://www.polarsys.org/capella/core/cs/1.4.0"
+    xmlns:org.polarsys.capella.core.data.ctx="http://www.polarsys.org/capella/core/ctx/1.4.0"
+    xmlns:org.polarsys.capella.core.data.epbs="http://www.polarsys.org/capella/core/epbs/1.4.0"
+    xmlns:org.polarsys.capella.core.data.fa="http://www.polarsys.org/capella/core/fa/1.4.0"
+    xmlns:org.polarsys.capella.core.data.information="http://www.polarsys.org/capella/core/information/1.4.0"
+    xmlns:org.polarsys.capella.core.data.information.datatype="http://www.polarsys.org/capella/core/information/datatype/1.4.0"
+    xmlns:org.polarsys.capella.core.data.information.datavalue="http://www.polarsys.org/capella/core/information/datavalue/1.4.0"
+    xmlns:org.polarsys.capella.core.data.la="http://www.polarsys.org/capella/core/la/1.4.0"
+    xmlns:org.polarsys.capella.core.data.oa="http://www.polarsys.org/capella/core/oa/1.4.0"
+    xmlns:org.polarsys.capella.core.data.pa="http://www.polarsys.org/capella/core/pa/1.4.0"
+    xmlns:org.polarsys.capella.core.data.pa.deployment="http://www.polarsys.org/capella/core/pa/deployment/1.4.0"
+    id="a1f728c7-5376-4c85-9273-9ac86ed76290"
+    name="MassProject">
+  <ownedExtensions xsi:type="libraries:ModelInformation" id="e2d17734-e112-43bb-be11-aa1a1ae08ebe"/>
+  <ownedEnumerationPropertyTypes xsi:type="org.polarsys.capella.core.data.capellacore:EnumerationPropertyType"
+      id="486ce33e-30bd-4ef2-8f96-e909cd55ad5a" name="ProgressStatus">
+    <ownedLiterals xsi:type="org.polarsys.capella.core.data.capellacore:EnumerationPropertyLiteral"
+        id="3c1c1dfa-45ee-421f-a38c-cbe748ce0583" name="DRAFT"/>
+    <ownedLiterals xsi:type="org.polarsys.capella.core.data.capellacore:EnumerationPropertyLiteral"
+        id="ab90b723-f0db-471f-a5c0-e8ded646d518" name="TO_BE_REVIEWED"/>
+    <ownedLiterals xsi:type="org.polarsys.capella.core.data.capellacore:EnumerationPropertyLiteral"
+        id="8bfcb7e0-2e53-41cd-aad9-445ee37c1e1b" name="TO_BE_DISCUSSED"/>
+    <ownedLiterals xsi:type="org.polarsys.capella.core.data.capellacore:EnumerationPropertyLiteral"
+        id="5668f648-b622-4d72-9e03-e21e730225a1" name="REWORK_NECESSARY"/>
+    <ownedLiterals xsi:type="org.polarsys.capella.core.data.capellacore:EnumerationPropertyLiteral"
+        id="516ae1bb-bc41-42a8-baba-25a6dd1080ca" name="UNDER_REWORK"/>
+    <ownedLiterals xsi:type="org.polarsys.capella.core.data.capellacore:EnumerationPropertyLiteral"
+        id="6a7ef201-87e9-47f3-8050-5b27438e5c52" name="REVIEWED_OK"/>
+  </ownedEnumerationPropertyTypes>
+  <keyValuePairs xsi:type="org.polarsys.capella.core.data.capellacore:KeyValue" id="6f3a7e09-3d2f-40f8-8e2b-442198c9201a"
+      key="projectApproach" value="SingletonComponents"/>
+  <ownedModelRoots xsi:type="org.polarsys.capella.core.data.capellamodeller:SystemEngineering"
+      id="505b2517-c704-4052-97f8-2a7ff22373f0" name="MassProject">
+    <ownedArchitectures xsi:type="org.polarsys.capella.core.data.oa:OperationalAnalysis"
+        id="56de713f-3a5d-4572-9a51-e29fedc39ada" name="Operational Analysis">
+      <ownedFunctionPkg xsi:type="org.polarsys.capella.core.data.oa:OperationalActivityPkg"
+          id="71a4058b-0219-43da-a915-55124cb1efdd" name="Operational Activities">
+        <ownedOperationalActivities xsi:type="org.polarsys.capella.core.data.oa:OperationalActivity"
+            id="f6ad4b2a-c15b-4944-a0c6-7f60ba61384e" name="Root Operational Activity"/>
+      </ownedFunctionPkg>
+      <ownedAbstractCapabilityPkg xsi:type="org.polarsys.capella.core.data.oa:OperationalCapabilityPkg"
+          id="2305ffe2-d80e-4a7f-9add-91c6b9f0a6f5" name="Operational Capabilities"/>
+      <ownedInterfacePkg xsi:type="org.polarsys.capella.core.data.cs:InterfacePkg"
+          id="df83b04a-b26a-42ac-bb94-03a2120d6d10" name="Interfaces"/>
+      <ownedDataPkg xsi:type="org.polarsys.capella.core.data.information:DataPkg"
+          id="8c0ace7f-ae26-490e-8800-72b7cd703e3c" name="Data"/>
+      <ownedRolePkg xsi:type="org.polarsys.capella.core.data.oa:RolePkg" id="f9be9e90-0b06-4138-a638-0ea5d534f57d"
+          name="Roles"/>
+      <ownedEntityPkg xsi:type="org.polarsys.capella.core.data.oa:EntityPkg" id="046f29f8-3081-4b45-92de-414451fa862e"
+          name="Operational Entities"/>
+    </ownedArchitectures>
+    <ownedArchitectures xsi:type="org.polarsys.capella.core.data.ctx:SystemAnalysis"
+        id="84b41fea-45f0-4041-99a5-ee329fb954bc" name="System Analysis">
+      <ownedFunctionPkg xsi:type="org.polarsys.capella.core.data.ctx:SystemFunctionPkg"
+          id="72417000-c22d-48d5-b52d-cd9d1e12a9b6" name="System Functions">
+        <ownedSystemFunctions xsi:type="org.polarsys.capella.core.data.ctx:SystemFunction"
+            id="1b4286e1-bf56-4adb-962c-d4be6eeb5fc3" name="Root System Function">
+          <ownedFunctionRealizations xsi:type="org.polarsys.capella.core.data.fa:FunctionRealization"
+              id="bb06a7e9-d3d9-4a4f-b7fd-fbe9ac71608f" targetElement="#f6ad4b2a-c15b-4944-a0c6-7f60ba61384e"
+              sourceElement="#1b4286e1-bf56-4adb-962c-d4be6eeb5fc3"/>
+        </ownedSystemFunctions>
+      </ownedFunctionPkg>
+      <ownedAbstractCapabilityPkg xsi:type="org.polarsys.capella.core.data.ctx:CapabilityPkg"
+          id="5d15e000-7f76-47e6-a02b-ce041e2afd3a" name="Capabilities"/>
+      <ownedInterfacePkg xsi:type="org.polarsys.capella.core.data.cs:InterfacePkg"
+          id="123ba8bf-e8fb-41d2-9c87-778a8a5b31e5" name="Interfaces"/>
+      <ownedDataPkg xsi:type="org.polarsys.capella.core.data.information:DataPkg"
+          id="fa595cf8-f5ff-495a-80b2-de42fe9ecc27" name="Data">
+        <ownedDataPkgs xsi:type="org.polarsys.capella.core.data.information:DataPkg"
+            id="45724d6d-2990-4c55-b54f-56fb7aea6f54" name="Predefined Types">
+          <ownedDataTypes xsi:type="org.polarsys.capella.core.data.information.datatype:BooleanType"
+              id="a86797b7-8ad2-4a93-9d3e-5c6863372dda" name="Boolean" visibility="PUBLIC">
+            <ownedLiterals xsi:type="org.polarsys.capella.core.data.information.datavalue:LiteralBooleanValue"
+                id="711344a4-c14b-4357-b254-064aae9ce4f8" name="True" abstractType="#a86797b7-8ad2-4a93-9d3e-5c6863372dda"
+                value="true"/>
+            <ownedLiterals xsi:type="org.polarsys.capella.core.data.information.datavalue:LiteralBooleanValue"
+                id="3f462a0b-62d5-4a2d-bf25-450f30cef961" name="False" abstractType="#a86797b7-8ad2-4a93-9d3e-5c6863372dda"/>
+          </ownedDataTypes>
+          <ownedDataTypes xsi:type="org.polarsys.capella.core.data.information.datatype:NumericType"
+              id="6b91e038-aada-4438-a5d9-c23d1d7a3df1" name="Byte" visibility="PUBLIC">
+            <ownedMinValue xsi:type="org.polarsys.capella.core.data.information.datavalue:LiteralNumericValue"
+                id="f43a8ef1-d823-42b7-b4e4-1a00eb77f86f" name="" abstractType="#6b91e038-aada-4438-a5d9-c23d1d7a3df1"
+                value="0"/>
+            <ownedMaxValue xsi:type="org.polarsys.capella.core.data.information.datavalue:LiteralNumericValue"
+                id="28b86e04-6894-41e7-9986-ff7a2e52ab9a" name="" abstractType="#6b91e038-aada-4438-a5d9-c23d1d7a3df1"
+                value="255"/>
+          </ownedDataTypes>
+          <ownedDataTypes xsi:type="org.polarsys.capella.core.data.information.datatype:StringType"
+              id="cc8ce309-500d-4de4-a722-ea024cfa8cc1" name="Char" visibility="PUBLIC">
+            <ownedMinLength xsi:type="org.polarsys.capella.core.data.information.datavalue:LiteralNumericValue"
+                id="9ca1b067-19e5-4664-8042-d884b59667df" name="" abstractType="#43c81666-31a9-4aac-bab1-4cff2dbb2e73"
+                value="1"/>
+            <ownedMaxLength xsi:type="org.polarsys.capella.core.data.information.datavalue:LiteralNumericValue"
+                id="0b314487-61d6-4b5d-8c7e-cd262841946b" name="" abstractType="#43c81666-31a9-4aac-bab1-4cff2dbb2e73"
+                value="1"/>
+          </ownedDataTypes>
+          <ownedDataTypes xsi:type="org.polarsys.capella.core.data.information.datatype:NumericType"
+              id="1dafcdc0-f027-4267-80ad-8a8d43d3495d" name="Double" discrete="false"
+              visibility="PUBLIC" kind="FLOAT"/>
+          <ownedDataTypes xsi:type="org.polarsys.capella.core.data.information.datatype:NumericType"
+              id="38d70117-7e7f-4106-9eeb-cfb163b5a178" name="Float" discrete="false"
+              visibility="PUBLIC" kind="FLOAT"/>
+          <ownedDataTypes xsi:type="org.polarsys.capella.core.data.information.datatype:NumericType"
+              id="0899fea0-43aa-4d66-b350-55c6e5302ee4" name="Hexadecimal" visibility="PUBLIC">
+            <ownedMinValue xsi:type="org.polarsys.capella.core.data.information.datavalue:LiteralNumericValue"
+                id="d0d8af91-f2c2-48cd-98b6-f8e676e4cdde" name="" abstractType="#0899fea0-43aa-4d66-b350-55c6e5302ee4"
+                value="0"/>
+            <ownedMaxValue xsi:type="org.polarsys.capella.core.data.information.datavalue:BinaryExpression"
+                id="b7925315-b597-4519-8434-313bed8e2b16" abstractType="#0899fea0-43aa-4d66-b350-55c6e5302ee4"
+                operator="SUB">
+              <ownedLeftOperand xsi:type="org.polarsys.capella.core.data.information.datavalue:BinaryExpression"
+                  id="61c50fed-3de2-40dc-a230-31e2f56c95a8" operator="POW">
+                <ownedLeftOperand xsi:type="org.polarsys.capella.core.data.information.datavalue:LiteralNumericValue"
+                    id="e5203aa9-a131-49cf-9ea2-49516e41842e" value="2"/>
+                <ownedRightOperand xsi:type="org.polarsys.capella.core.data.information.datavalue:LiteralNumericValue"
+                    id="25e44660-9f1b-4a6f-b24f-5e748637d82f" value="64"/>
+              </ownedLeftOperand>
+              <ownedRightOperand xsi:type="org.polarsys.capella.core.data.information.datavalue:LiteralNumericValue"
+                  id="9b12bb44-652c-42dd-b33e-6106d032a43d" value="1"/>
+            </ownedMaxValue>
+          </ownedDataTypes>
+          <ownedDataTypes xsi:type="org.polarsys.capella.core.data.information.datatype:NumericType"
+              id="a621604b-76c7-477f-8ead-f2dfbb9898e2" name="Integer" visibility="PUBLIC"/>
+          <ownedDataTypes xsi:type="org.polarsys.capella.core.data.information.datatype:NumericType"
+              id="f937dc74-b7f0-4ac1-8e8f-6789e1f8ef17" name="Long" visibility="PUBLIC"/>
+          <ownedDataTypes xsi:type="org.polarsys.capella.core.data.information.datatype:NumericType"
+              id="b761985a-c519-4956-ad0e-ba884c954763" name="LongLong" visibility="PUBLIC"/>
+          <ownedDataTypes xsi:type="org.polarsys.capella.core.data.information.datatype:NumericType"
+              id="64fe37bf-c713-492d-afbc-2744261aeca3" name="Short" visibility="PUBLIC"/>
+          <ownedDataTypes xsi:type="org.polarsys.capella.core.data.information.datatype:StringType"
+              id="763de17c-9a89-4b7f-89a4-a231f7ed22ab" name="String" visibility="PUBLIC"/>
+          <ownedDataTypes xsi:type="org.polarsys.capella.core.data.information.datatype:NumericType"
+              id="10f99cb1-e8fa-4289-bda1-dc8a2c862963" name="UnsignedInteger" maxInclusive="false"
+              visibility="PUBLIC">
+            <ownedMinValue xsi:type="org.polarsys.capella.core.data.information.datavalue:LiteralNumericValue"
+                id="a33c57ba-ab2c-4b28-ac2b-ed82438520ba" name="" abstractType="#10f99cb1-e8fa-4289-bda1-dc8a2c862963"
+                value="0"/>
+          </ownedDataTypes>
+          <ownedDataTypes xsi:type="org.polarsys.capella.core.data.information.datatype:NumericType"
+              id="43c81666-31a9-4aac-bab1-4cff2dbb2e73" name="UnsignedShort" maxInclusive="false"
+              visibility="PUBLIC">
+            <ownedMinValue xsi:type="org.polarsys.capella.core.data.information.datavalue:LiteralNumericValue"
+                id="aa5c3bed-ad77-4868-9ec3-36497a376fc7" name="" abstractType="#43c81666-31a9-4aac-bab1-4cff2dbb2e73"
+                value="0"/>
+          </ownedDataTypes>
+          <ownedDataTypes xsi:type="org.polarsys.capella.core.data.information.datatype:NumericType"
+              id="a0a68500-7d13-4911-bc83-6f8d56853813" name="UnsignedLong" maxInclusive="false"
+              visibility="PUBLIC">
+            <ownedMinValue xsi:type="org.polarsys.capella.core.data.information.datavalue:LiteralNumericValue"
+                id="d1912a6b-59ec-4df8-9618-c3eee5f83029" name="" abstractType="#a0a68500-7d13-4911-bc83-6f8d56853813"
+                value="0"/>
+          </ownedDataTypes>
+          <ownedDataTypes xsi:type="org.polarsys.capella.core.data.information.datatype:NumericType"
+              id="1cf5ce72-254a-4132-9f81-9f7416a5b567" name="UnsignedLongLong" maxInclusive="false"
+              visibility="PUBLIC">
+            <ownedMinValue xsi:type="org.polarsys.capella.core.data.information.datavalue:LiteralNumericValue"
+                id="99132ed4-e2a6-4d09-aa83-318615b4ad01" name="" abstractType="#1cf5ce72-254a-4132-9f81-9f7416a5b567"
+                value="0"/>
+          </ownedDataTypes>
+        </ownedDataPkgs>
+      </ownedDataPkg>
+      <ownedSystemComponentPkg xsi:type="org.polarsys.capella.core.data.ctx:SystemComponentPkg"
+          id="983cd603-cb0c-464f-8b8d-4a5a4f8a6de4" name="Structure">
+        <ownedParts xsi:type="org.polarsys.capella.core.data.cs:Part" id="963ab97b-4978-4acb-a382-4e987cc89fe3"
+            name="System" abstractType="#f2477cc8-c845-4666-b613-4fe935cb794a"/>
+        <ownedSystemComponents xsi:type="org.polarsys.capella.core.data.ctx:SystemComponent"
+            id="f2477cc8-c845-4666-b613-4fe935cb794a" name="System">
+          <ownedStateMachines xsi:type="org.polarsys.capella.core.data.capellacommon:StateMachine"
+              id="8e350c89-932b-4d01-965f-de558d67e339" name="System State Machine">
+            <ownedRegions xsi:type="org.polarsys.capella.core.data.capellacommon:Region"
+                id="4d4b19c7-6eec-4edd-9498-d2bf5c4aa734" name="Default Region"/>
+          </ownedStateMachines>
+        </ownedSystemComponents>
+      </ownedSystemComponentPkg>
+      <ownedMissionPkg xsi:type="org.polarsys.capella.core.data.ctx:MissionPkg" id="956b9311-8a7d-4aad-8da7-6ffc585ecda1"
+          name="Missions"/>
+      <ownedOperationalAnalysisRealizations xsi:type="org.polarsys.capella.core.data.ctx:OperationalAnalysisRealization"
+          id="9f09c7fe-114c-4593-93f5-f39dc7b13dfc" targetElement="#56de713f-3a5d-4572-9a51-e29fedc39ada"
+          sourceElement="#84b41fea-45f0-4041-99a5-ee329fb954bc"/>
+    </ownedArchitectures>
+    <ownedArchitectures xsi:type="org.polarsys.capella.core.data.la:LogicalArchitecture"
+        id="62421b63-cf74-43b7-b43c-a9077be34b23" name="Logical Architecture">
+      <ownedFunctionPkg xsi:type="org.polarsys.capella.core.data.la:LogicalFunctionPkg"
+          id="adf6a70f-d18d-4828-9872-5119be44927b" name="Logical Functions">
+        <ownedLogicalFunctions xsi:type="org.polarsys.capella.core.data.la:LogicalFunction"
+            id="2a17edde-5be0-4e46-8d1d-fc25aa78afb4" name="Root Logical Function">
+          <ownedFunctionRealizations xsi:type="org.polarsys.capella.core.data.fa:FunctionRealization"
+              id="bb06688e-e54a-4f48-9435-c4050f13236e" targetElement="#1b4286e1-bf56-4adb-962c-d4be6eeb5fc3"
+              sourceElement="#2a17edde-5be0-4e46-8d1d-fc25aa78afb4"/>
+        </ownedLogicalFunctions>
+      </ownedFunctionPkg>
+      <ownedAbstractCapabilityPkg xsi:type="org.polarsys.capella.core.data.la:CapabilityRealizationPkg"
+          id="544a4c67-18de-4e17-bbf9-c57e47524f7d" name="Capabilities"/>
+      <ownedInterfacePkg xsi:type="org.polarsys.capella.core.data.cs:InterfacePkg"
+          id="7d9863b3-4d62-4b78-9565-c5dcfe267fa7" name="Interfaces"/>
+      <ownedDataPkg xsi:type="org.polarsys.capella.core.data.information:DataPkg"
+          id="045669ec-82c3-47cc-863e-3584f746fe37" name="Data"/>
+      <ownedLogicalComponentPkg xsi:type="org.polarsys.capella.core.data.la:LogicalComponentPkg"
+          id="341c6143-be54-4326-962b-d7377f3ccf4a" name="Structure">
+        <ownedParts xsi:type="org.polarsys.capella.core.data.cs:Part" id="feabdfb9-7402-40b9-b128-e6d72ad9d8ee"
+            name="Logical System" abstractType="#2c418425-d0d0-4474-9eba-4cabea344d1c"/>
+        <ownedLogicalComponents xsi:type="org.polarsys.capella.core.data.la:LogicalComponent"
+            id="2c418425-d0d0-4474-9eba-4cabea344d1c" name="Logical System">
+          <ownedComponentRealizations xsi:type="org.polarsys.capella.core.data.cs:ComponentRealization"
+              id="70e1cd7c-9bc4-48ac-a289-36534574f505" targetElement="#f2477cc8-c845-4666-b613-4fe935cb794a"
+              sourceElement="#2c418425-d0d0-4474-9eba-4cabea344d1c"/>
+        </ownedLogicalComponents>
+      </ownedLogicalComponentPkg>
+      <ownedSystemAnalysisRealizations xsi:type="org.polarsys.capella.core.data.la:SystemAnalysisRealization"
+          id="57c41e71-49b1-4266-934d-deaca5937f3b" targetElement="#84b41fea-45f0-4041-99a5-ee329fb954bc"
+          sourceElement="#62421b63-cf74-43b7-b43c-a9077be34b23"/>
+    </ownedArchitectures>
+    <ownedArchitectures xsi:type="org.polarsys.capella.core.data.pa:PhysicalArchitecture"
+        id="20d75d0c-244d-419e-99da-0565cfe26bdc" name="Physical Architecture">
+      <ownedFunctionPkg xsi:type="org.polarsys.capella.core.data.pa:PhysicalFunctionPkg"
+          id="7de804fc-b5a9-468a-86b3-2dab33b367eb" name="Physical Functions">
+        <ownedPhysicalFunctions xsi:type="org.polarsys.capella.core.data.pa:PhysicalFunction"
+            id="c89b07ad-09c9-47d7-9aeb-d8fd542cf5f8" name="Root Physical Function">
+          <ownedFunctionRealizations xsi:type="org.polarsys.capella.core.data.fa:FunctionRealization"
+              id="80fc3076-68f7-4a76-803f-366b7cb4e0e7" targetElement="#2a17edde-5be0-4e46-8d1d-fc25aa78afb4"
+              sourceElement="#c89b07ad-09c9-47d7-9aeb-d8fd542cf5f8"/>
+        </ownedPhysicalFunctions>
+      </ownedFunctionPkg>
+      <ownedAbstractCapabilityPkg xsi:type="org.polarsys.capella.core.data.la:CapabilityRealizationPkg"
+          id="a36e66f3-baea-4e7e-b0b0-9a0ae953c670" name="Capabilities"/>
+      <ownedInterfacePkg xsi:type="org.polarsys.capella.core.data.cs:InterfacePkg"
+          id="2ead6096-2f14-416f-8d03-ca05f1ce17ed" name="Interfaces"/>
+      <ownedDataPkg xsi:type="org.polarsys.capella.core.data.information:DataPkg"
+          id="f935fd16-97d4-4716-aa24-bf2ce5bcf7be" name="Data"/>
+      <ownedPhysicalComponentPkg xsi:type="org.polarsys.capella.core.data.pa:PhysicalComponentPkg"
+          id="000ec20a-6206-477f-a742-6417048338e1" name="Structure">
+        <ownedParts xsi:type="org.polarsys.capella.core.data.cs:Part" id="596e4c03-4621-43d7-b4df-5b07dd3791a3"
+            name="Physical System" abstractType="#a46cf121-0ab5-47ec-85c4-5e8d9830a314"/>
+        <ownedPhysicalComponents xsi:type="org.polarsys.capella.core.data.pa:PhysicalComponent"
+            id="a46cf121-0ab5-47ec-85c4-5e8d9830a314" name="Physical System">
+          <ownedFeatures xsi:type="org.polarsys.capella.core.data.cs:Part" id="627b6bf1-73e6-4e7e-af25-608742f03575"
+              name="PC 1" abstractType="#820e2f61-8ea2-4db9-860f-90ff366c3728">
+            <ownedExtensions xsi:type="mass:PartMass" id="_p9sWAF1jEeqBCMjfTVrmpQ"
+                value="20" maxValue="50"/>
+            <ownedDeploymentLinks xsi:type="org.polarsys.capella.core.data.pa.deployment:PartDeploymentLink"
+                id="eb503fe0-0a97-48cb-b823-8aa8f1b14b5f" deployedElement="#695c334e-b5eb-4bc2-9ab7-cfe541cb4feb"
+                location="#627b6bf1-73e6-4e7e-af25-608742f03575"/>
+            <ownedDeploymentLinks xsi:type="org.polarsys.capella.core.data.pa.deployment:PartDeploymentLink"
+                id="dfaaa688-a43c-4815-965a-2eef59bfbdd8" deployedElement="#c97ec17c-d34c-4d89-b50c-8b458ba1b177"
+                location="#627b6bf1-73e6-4e7e-af25-608742f03575"/>
+          </ownedFeatures>
+          <ownedFeatures xsi:type="org.polarsys.capella.core.data.cs:Part" id="695c334e-b5eb-4bc2-9ab7-cfe541cb4feb"
+              name="PC 1.2" abstractType="#815f060d-7821-4fc6-b889-a984b92099d7">
+            <ownedExtensions xsi:type="mass:PartMass" id="_ADoagF31EeqOkcuQb7nmWw"
+                value="10" maxValue="10"/>
+            <ownedDeploymentLinks xsi:type="org.polarsys.capella.core.data.pa.deployment:PartDeploymentLink"
+                id="b294a2a5-2353-4f36-a14e-3af70454c7ad" deployedElement="#a9f25446-4966-4b88-92fe-0ea1de344365"
+                location="#695c334e-b5eb-4bc2-9ab7-cfe541cb4feb"/>
+          </ownedFeatures>
+          <ownedFeatures xsi:type="org.polarsys.capella.core.data.cs:Part" id="a9f25446-4966-4b88-92fe-0ea1de344365"
+              name="PC 1.2.1" abstractType="#1f7fef9c-b17d-4ba1-b509-d7e8d188a7e7">
+            <ownedExtensions xsi:type="mass:PartMass" id="_7c7GYF36EeqOkcuQb7nmWw"
+                value="5" maxValue="10"/>
+          </ownedFeatures>
+          <ownedFeatures xsi:type="org.polarsys.capella.core.data.cs:Part" id="c97ec17c-d34c-4d89-b50c-8b458ba1b177"
+              name="PC 1.4" abstractType="#a7ff18b5-8fb0-4cb2-b6d2-7deab56d6b24"/>
+          <ownedComponentRealizations xsi:type="org.polarsys.capella.core.data.cs:ComponentRealization"
+              id="f111f2d2-67e9-45d6-ad84-c5a1e57616e4" targetElement="#2c418425-d0d0-4474-9eba-4cabea344d1c"
+              sourceElement="#a46cf121-0ab5-47ec-85c4-5e8d9830a314"/>
+          <ownedPhysicalComponents xsi:type="org.polarsys.capella.core.data.pa:PhysicalComponent"
+              id="820e2f61-8ea2-4db9-860f-90ff366c3728" name="PC 1" nature="NODE">
+            <ownedFeatures xsi:type="org.polarsys.capella.core.data.cs:Part" id="5031e230-e037-4178-8537-da1af39d62c3"
+                name="PC 1.1" abstractType="#a2c7a4ee-aa96-46cf-bb44-413cb2dedbe9">
+              <ownedExtensions xsi:type="mass:PartMass" id="_rwQf0F1jEeqBCMjfTVrmpQ"
+                  value="50" maxValue="100"/>
+            </ownedFeatures>
+            <ownedFeatures xsi:type="org.polarsys.capella.core.data.cs:Part" id="28a096c4-0e5f-4c34-b027-1edd2ffeeb61"
+                name="PC 1.3" abstractType="#143ddf10-5165-49f8-a678-1c53fe697628"/>
+            <ownedPhysicalComponents xsi:type="org.polarsys.capella.core.data.pa:PhysicalComponent"
+                id="a2c7a4ee-aa96-46cf-bb44-413cb2dedbe9" name="PC 1.1" nature="NODE"/>
+            <ownedPhysicalComponents xsi:type="org.polarsys.capella.core.data.pa:PhysicalComponent"
+                id="143ddf10-5165-49f8-a678-1c53fe697628" name="PC 1.3" nature="NODE"/>
+          </ownedPhysicalComponents>
+          <ownedPhysicalComponents xsi:type="org.polarsys.capella.core.data.pa:PhysicalComponent"
+              id="815f060d-7821-4fc6-b889-a984b92099d7" name="PC 1.2" nature="BEHAVIOR"/>
+          <ownedPhysicalComponents xsi:type="org.polarsys.capella.core.data.pa:PhysicalComponent"
+              id="1f7fef9c-b17d-4ba1-b509-d7e8d188a7e7" name="PC 1.2.1" nature="BEHAVIOR"/>
+          <ownedPhysicalComponents xsi:type="org.polarsys.capella.core.data.pa:PhysicalComponent"
+              id="a7ff18b5-8fb0-4cb2-b6d2-7deab56d6b24" name="PC 1.4" nature="BEHAVIOR"/>
+        </ownedPhysicalComponents>
+      </ownedPhysicalComponentPkg>
+      <ownedLogicalArchitectureRealizations xsi:type="org.polarsys.capella.core.data.pa:LogicalArchitectureRealization"
+          id="f44990a3-0257-4524-a828-0e7fcbbe96e3" targetElement="#62421b63-cf74-43b7-b43c-a9077be34b23"
+          sourceElement="#20d75d0c-244d-419e-99da-0565cfe26bdc"/>
+    </ownedArchitectures>
+    <ownedArchitectures xsi:type="org.polarsys.capella.core.data.epbs:EPBSArchitecture"
+        id="5a05cb77-5c09-4891-b640-0f2f984ba0f8" name="EPBS Architecture">
+      <ownedAbstractCapabilityPkg xsi:type="org.polarsys.capella.core.data.la:CapabilityRealizationPkg"
+          id="4e76ba2b-7b12-4981-9db8-64c8e60c8a84" name="Capabilities"/>
+      <ownedConfigurationItemPkg xsi:type="org.polarsys.capella.core.data.epbs:ConfigurationItemPkg"
+          id="568c954e-1c50-4c1f-b102-edd25b88a34f" name="Structure">
+        <ownedParts xsi:type="org.polarsys.capella.core.data.cs:Part" id="9f654624-c8a2-4253-a7d6-4bfbe793c0c5"
+            name="System" abstractType="#f806c2cb-25aa-4565-9971-90fcb4d97efc"/>
+        <ownedConfigurationItems xsi:type="org.polarsys.capella.core.data.epbs:ConfigurationItem"
+            id="f806c2cb-25aa-4565-9971-90fcb4d97efc" name="System" kind="SystemCI">
+          <ownedPhysicalArtifactRealizations xsi:type="org.polarsys.capella.core.data.epbs:PhysicalArtifactRealization"
+              id="eb433220-9428-4c05-b461-d22af5f7a955" targetElement="#a46cf121-0ab5-47ec-85c4-5e8d9830a314"
+              sourceElement="#f806c2cb-25aa-4565-9971-90fcb4d97efc"/>
+        </ownedConfigurationItems>
+      </ownedConfigurationItemPkg>
+      <ownedPhysicalArchitectureRealizations xsi:type="org.polarsys.capella.core.data.epbs:PhysicalArchitectureRealization"
+          id="9086541c-2312-42ec-ace6-c8436744679d" targetElement="#20d75d0c-244d-419e-99da-0565cfe26bdc"
+          sourceElement="#5a05cb77-5c09-4891-b640-0f2f984ba0f8"/>
+    </ownedArchitectures>
+  </ownedModelRoots>
+</org.polarsys.capella.core.data.capellamodeller:Project>

--- a/massviewpoint/tests/org.polarsys.capella.vp.mass.ju/pom.xml
+++ b/massviewpoint/tests/org.polarsys.capella.vp.mass.ju/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright (c) 2020 OBEO
+  Copyright (c) 2020 Obeo
   All rights reserved. This program and the accompanying materials
   are made available under the terms of the Eclipse Public License v1.0
   which accompanies this distribution, and is available at

--- a/massviewpoint/tests/org.polarsys.capella.vp.mass.ju/pom.xml
+++ b/massviewpoint/tests/org.polarsys.capella.vp.mass.ju/pom.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright (c) 2020 OBEO
+  All rights reserved. This program and the accompanying materials
+  are made available under the terms of the Eclipse Public License v1.0
+  which accompanies this distribution, and is available at
+  http://www.eclipse.org/legal/epl-v10.html
+
+  Contributors:
+       Obeo - initial API and implementation
+-->
+<project
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+	xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>org.polarsys</groupId>
+	<artifactId>org.polarsys.capella.vp.mass.ju</artifactId>
+	<packaging>eclipse-test-plugin</packaging>
+
+	<parent>
+		<groupId>org.polarsys</groupId>
+		<artifactId>org.polarsys.capella.basic.mass.viewpoint.tests</artifactId>
+		<version>1.4.0-SNAPSHOT</version>
+		<relativePath>../</relativePath>
+	</parent>
+	
+	<build>
+  		<plugins>
+  			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-surefire-plugin</artifactId>
+				<version>${tycho-version}</version>
+				<configuration>
+					<product>${capella-rcp-product-id}</product>
+					<application>${capella-application-id}</application>
+					<useUIHarness>true</useUIHarness>
+					<useUIThread>false</useUIThread>
+					<testSuite>org.polarsys.capella.vp.mass.ju</testSuite>
+					<testClass>org.polarsys.capella.vp.mass.ju.MassSessionListenerTestSuite</testClass>
+					<dependencies>
+						<!-- see https://bugs.eclipse.org/bugs/show_bug.cgi?id=462862 -->
+						<dependency>
+							<type>eclipse-plugin</type>
+							<artifactId>org.eclipse.equinox.event</artifactId>
+							<version>0.0.0</version>
+						</dependency>
+					</dependencies>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>target-platform-configuration</artifactId>
+				<version>${tycho-version}</version>
+				<configuration>
+					<environments combine.self="override"/>
+					<dependency-resolution>
+						<extraRequirements>
+							<requirement>
+								<type>eclipse-feature</type>
+								<id>org.polarsys.capella.rcp.feature</id>
+								<versionRange>0.0.0</versionRange>
+							</requirement>
+							<requirement>
+								<type>eclipse-feature</type>
+								<id>org.polarsys.capella.vp.mass.feature</id>
+								<versionRange>0.0.0</versionRange>
+							</requirement>
+						</extraRequirements>
+					</dependency-resolution>
+				</configuration>
+			</plugin>
+  		</plugins>
+ 	</build>
+</project>

--- a/massviewpoint/tests/org.polarsys.capella.vp.mass.ju/src/org/polarsys/capella/vp/mass/ju/MassSessionListenerTestSuite.java
+++ b/massviewpoint/tests/org.polarsys.capella.vp.mass.ju/src/org/polarsys/capella/vp/mass/ju/MassSessionListenerTestSuite.java
@@ -1,0 +1,59 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Obeo
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License v1.0
+ *   which accompanies this distribution, and is available at
+ *   http://www.eclipse.org/legal/epl-v10.html
+ * 
+ *   Contributors:
+ *      OBEO - initial API and implementation
+ ******************************************************************************/
+package org.polarsys.capella.vp.mass.ju;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.polarsys.capella.test.framework.api.BasicTestArtefact;
+import org.polarsys.capella.test.framework.api.BasicTestSuite;
+import org.polarsys.capella.vp.mass.ju.testCase.AddMassBehaviorTest;
+import org.polarsys.capella.vp.mass.ju.testCase.AddMassNodeTest;
+import org.polarsys.capella.vp.mass.ju.testCase.DeleteBehaviorWithMassTest;
+import org.polarsys.capella.vp.mass.ju.testCase.DeleteNodeWithMassTest;
+import org.polarsys.capella.vp.mass.ju.testCase.DeletePartMassBehaviorTest;
+import org.polarsys.capella.vp.mass.ju.testCase.DeletePartMassNodeTest;
+import org.polarsys.capella.vp.mass.ju.testCase.EditMassBehaviorTest;
+import org.polarsys.capella.vp.mass.ju.testCase.EditMassNodeTest;
+import org.polarsys.capella.vp.mass.ju.testCase.MassCalculatedOpeningSessionTest;
+
+import junit.framework.Test;
+
+/**
+ * This test suite starts tests that check whether the mass listeners are
+ * correctly installed, and if the mass of the elements is correctly calculated
+ * after certain events
+ */
+public class MassSessionListenerTestSuite extends BasicTestSuite {
+
+	/**
+	 * Returns the suite. This is required to unary launch this test.
+	 */
+	public static Test suite() {
+		return new MassSessionListenerTestSuite();
+	}
+
+	@Override
+	protected List<BasicTestArtefact> getTests() {
+		List<BasicTestArtefact> tests = new ArrayList<BasicTestArtefact>();
+		tests.add(new MassCalculatedOpeningSessionTest());
+		tests.add(new EditMassNodeTest());
+		tests.add(new EditMassBehaviorTest());
+		tests.add(new AddMassNodeTest());
+		tests.add(new AddMassBehaviorTest());
+		tests.add(new DeleteNodeWithMassTest());
+		tests.add(new DeleteBehaviorWithMassTest());
+		tests.add(new DeletePartMassBehaviorTest());
+		tests.add(new DeletePartMassNodeTest());
+		return tests;
+	}
+
+}

--- a/massviewpoint/tests/org.polarsys.capella.vp.mass.ju/src/org/polarsys/capella/vp/mass/ju/MassSessionListenerTestSuite.java
+++ b/massviewpoint/tests/org.polarsys.capella.vp.mass.ju/src/org/polarsys/capella/vp/mass/ju/MassSessionListenerTestSuite.java
@@ -6,7 +6,7 @@
  *   http://www.eclipse.org/legal/epl-v10.html
  * 
  *   Contributors:
- *      OBEO - initial API and implementation
+ *      Obeo - initial API and implementation
  ******************************************************************************/
 package org.polarsys.capella.vp.mass.ju;
 

--- a/massviewpoint/tests/org.polarsys.capella.vp.mass.ju/src/org/polarsys/capella/vp/mass/ju/testCase/AddMassBehaviorTest.java
+++ b/massviewpoint/tests/org.polarsys.capella.vp.mass.ju/src/org/polarsys/capella/vp/mass/ju/testCase/AddMassBehaviorTest.java
@@ -1,0 +1,37 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Obeo
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License v1.0
+ *   which accompanies this distribution, and is available at
+ *   http://www.eclipse.org/legal/epl-v10.html
+ * 
+ *   Contributors:
+ *      OBEO - initial API and implementation
+ ******************************************************************************/
+package org.polarsys.capella.vp.mass.ju.testCase;
+
+import org.polarsys.capella.core.data.cs.impl.PartImpl;
+import org.polarsys.capella.core.data.pa.PhysicalComponent;
+import org.polarsys.capella.core.data.pa.impl.PhysicalComponentImpl;
+import org.polarsys.capella.vp.mass.mass.impl.PartMassImpl;
+
+/**
+ * This test case checks if when adding a mass to a Behavior PC the mass of its
+ * parents are re-calculated
+ */
+public class AddMassBehaviorTest extends MassTest {
+	PartMassImpl pc1PartMass;
+
+	@Override
+	public void test() throws Exception {
+
+		PhysicalComponent pc1 = physicalSystem.getOwnedPhysicalComponents().get(0);
+		pc1PartMass = (PartMassImpl) ((PartImpl) pc1.getAbstractTypedElements().get(0)).getOwnedExtensions().get(0);
+		PhysicalComponentImpl pc14 = (PhysicalComponentImpl) pc1.getDeployedPhysicalComponents().get(1);
+
+		// add a mass to pc1.3 and check if the mass of pc1 is re-calculated
+		addMassToPhysicalComponent(pc14, 10);
+		assertEquals("The mass of PC1 was not changed after the addition of pc1.4", pc1PartMass.getCurrentMass(), 95);
+
+	}
+}

--- a/massviewpoint/tests/org.polarsys.capella.vp.mass.ju/src/org/polarsys/capella/vp/mass/ju/testCase/AddMassBehaviorTest.java
+++ b/massviewpoint/tests/org.polarsys.capella.vp.mass.ju/src/org/polarsys/capella/vp/mass/ju/testCase/AddMassBehaviorTest.java
@@ -6,7 +6,7 @@
  *   http://www.eclipse.org/legal/epl-v10.html
  * 
  *   Contributors:
- *      OBEO - initial API and implementation
+ *      Obeo - initial API and implementation
  ******************************************************************************/
 package org.polarsys.capella.vp.mass.ju.testCase;
 

--- a/massviewpoint/tests/org.polarsys.capella.vp.mass.ju/src/org/polarsys/capella/vp/mass/ju/testCase/AddMassNodeTest.java
+++ b/massviewpoint/tests/org.polarsys.capella.vp.mass.ju/src/org/polarsys/capella/vp/mass/ju/testCase/AddMassNodeTest.java
@@ -6,7 +6,7 @@
  *   http://www.eclipse.org/legal/epl-v10.html
  * 
  *   Contributors:
- *      OBEO - initial API and implementation
+ *      Obeo - initial API and implementation
  ******************************************************************************/
 package org.polarsys.capella.vp.mass.ju.testCase;
 

--- a/massviewpoint/tests/org.polarsys.capella.vp.mass.ju/src/org/polarsys/capella/vp/mass/ju/testCase/AddMassNodeTest.java
+++ b/massviewpoint/tests/org.polarsys.capella.vp.mass.ju/src/org/polarsys/capella/vp/mass/ju/testCase/AddMassNodeTest.java
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Obeo
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License v1.0
+ *   which accompanies this distribution, and is available at
+ *   http://www.eclipse.org/legal/epl-v10.html
+ * 
+ *   Contributors:
+ *      OBEO - initial API and implementation
+ ******************************************************************************/
+package org.polarsys.capella.vp.mass.ju.testCase;
+
+import org.polarsys.capella.core.data.cs.impl.PartImpl;
+import org.polarsys.capella.core.data.pa.PhysicalComponent;
+import org.polarsys.capella.core.data.pa.impl.PhysicalComponentImpl;
+import org.polarsys.capella.vp.mass.mass.impl.PartMassImpl;
+
+/**
+ * This test case checks if after adding a mass to an already existing physical
+ * node, the mass of its parent is re-calculated
+ */
+public class AddMassNodeTest extends MassTest {
+	PartMassImpl pc1PartMass;
+	
+	@Override
+	public void test() throws Exception {
+		
+		PhysicalComponent pc1 = physicalSystem.getOwnedPhysicalComponents().get(0);
+		pc1PartMass = (PartMassImpl) ((PartImpl) pc1.getAbstractTypedElements().get(0)).getOwnedExtensions().get(0);
+		PhysicalComponentImpl pc13 = (PhysicalComponentImpl) pc1.getOwnedPhysicalComponents().get(1);
+		
+		// add a mass to pc1.3 and check if the mass of pc1 is re-calculated
+		addMassToPhysicalComponent(pc13, 10);
+		assertEquals("The mass of PC1 was not changed after the addition of pc1.3", pc1PartMass.getCurrentMass(), 95);
+
+	}
+
+}

--- a/massviewpoint/tests/org.polarsys.capella.vp.mass.ju/src/org/polarsys/capella/vp/mass/ju/testCase/DeleteBehaviorWithMassTest.java
+++ b/massviewpoint/tests/org.polarsys.capella.vp.mass.ju/src/org/polarsys/capella/vp/mass/ju/testCase/DeleteBehaviorWithMassTest.java
@@ -6,7 +6,7 @@
  *   http://www.eclipse.org/legal/epl-v10.html
  * 
  *   Contributors:
- *      OBEO - initial API and implementation
+ *      Obeo - initial API and implementation
  ******************************************************************************/
 package org.polarsys.capella.vp.mass.ju.testCase;
 

--- a/massviewpoint/tests/org.polarsys.capella.vp.mass.ju/src/org/polarsys/capella/vp/mass/ju/testCase/DeleteBehaviorWithMassTest.java
+++ b/massviewpoint/tests/org.polarsys.capella.vp.mass.ju/src/org/polarsys/capella/vp/mass/ju/testCase/DeleteBehaviorWithMassTest.java
@@ -1,0 +1,41 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Obeo
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License v1.0
+ *   which accompanies this distribution, and is available at
+ *   http://www.eclipse.org/legal/epl-v10.html
+ * 
+ *   Contributors:
+ *      OBEO - initial API and implementation
+ ******************************************************************************/
+package org.polarsys.capella.vp.mass.ju.testCase;
+
+import org.polarsys.capella.core.data.cs.impl.PartImpl;
+import org.polarsys.capella.core.data.pa.PhysicalComponent;
+import org.polarsys.capella.vp.mass.mass.impl.PartMassImpl;
+
+/**
+ * This test case checks if when deleting a behavior PC owning a partMass the
+ * mass of its parents is re-calculated
+ */
+public class DeleteBehaviorWithMassTest extends MassTest {
+
+	PartMassImpl pc1PartMass;
+	PartMassImpl pc12PartMass;
+	PhysicalComponent pc12;
+
+	@Override
+	public void test() throws Exception {
+
+		PhysicalComponent pc1 = physicalSystem.getOwnedPhysicalComponents().get(0);
+		pc1PartMass = (PartMassImpl) ((PartImpl) pc1.getAbstractTypedElements().get(0)).getOwnedExtensions().get(0);
+		pc12 = pc1.getDeployedPhysicalComponents().get(0);
+		pc12PartMass = (PartMassImpl) ((PartImpl) pc12.getAbstractTypedElements().get(0)).getOwnedExtensions().get(0);
+
+		// remove pc1.2 and check if the mass of pc1 is re-calculated
+		deleteElement(pc12);
+		assertEquals("The mass of PC1 was not changed after the deletion of pc1.1", pc1PartMass.getCurrentMass(), 70);
+
+	}
+
+}

--- a/massviewpoint/tests/org.polarsys.capella.vp.mass.ju/src/org/polarsys/capella/vp/mass/ju/testCase/DeleteNodeWithMassTest.java
+++ b/massviewpoint/tests/org.polarsys.capella.vp.mass.ju/src/org/polarsys/capella/vp/mass/ju/testCase/DeleteNodeWithMassTest.java
@@ -6,7 +6,7 @@
  *   http://www.eclipse.org/legal/epl-v10.html
  * 
  *   Contributors:
- *      OBEO - initial API and implementation
+ *      Obeo - initial API and implementation
  ******************************************************************************/
 package org.polarsys.capella.vp.mass.ju.testCase;
 

--- a/massviewpoint/tests/org.polarsys.capella.vp.mass.ju/src/org/polarsys/capella/vp/mass/ju/testCase/DeleteNodeWithMassTest.java
+++ b/massviewpoint/tests/org.polarsys.capella.vp.mass.ju/src/org/polarsys/capella/vp/mass/ju/testCase/DeleteNodeWithMassTest.java
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Obeo
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License v1.0
+ *   which accompanies this distribution, and is available at
+ *   http://www.eclipse.org/legal/epl-v10.html
+ * 
+ *   Contributors:
+ *      OBEO - initial API and implementation
+ ******************************************************************************/
+package org.polarsys.capella.vp.mass.ju.testCase;
+
+import org.polarsys.capella.core.data.cs.impl.PartImpl;
+import org.polarsys.capella.core.data.pa.PhysicalComponent;
+import org.polarsys.capella.vp.mass.mass.impl.PartMassImpl;
+
+/**
+ * This test case checks if when deleting a node the mass of its parent is
+ * re-calculated
+ */
+public class DeleteNodeWithMassTest extends MassTest {
+	PartMassImpl pc1PartMass;
+
+	@Override
+	public void test() throws Exception {
+		PhysicalComponent pc1 = physicalSystem.getOwnedPhysicalComponents().get(0);
+		pc1PartMass = (PartMassImpl) ((PartImpl) pc1.getAbstractTypedElements().get(0)).getOwnedExtensions().get(0);
+		PhysicalComponent pc11 = pc1.getOwnedPhysicalComponents().get(0);
+
+		// remove pc1.1 and check if the mass of pc1 is re-calculated
+		deleteElement(pc11);
+		assertEquals("The mass of PC1 was not changed after the deletion of pc1.1", pc1PartMass.getCurrentMass(), 35);
+
+	}
+
+}

--- a/massviewpoint/tests/org.polarsys.capella.vp.mass.ju/src/org/polarsys/capella/vp/mass/ju/testCase/DeletePartMassBehaviorTest.java
+++ b/massviewpoint/tests/org.polarsys.capella.vp.mass.ju/src/org/polarsys/capella/vp/mass/ju/testCase/DeletePartMassBehaviorTest.java
@@ -6,7 +6,7 @@
  *   http://www.eclipse.org/legal/epl-v10.html
  * 
  *   Contributors:
- *      OBEO - initial API and implementation
+ *      Obeo - initial API and implementation
  ******************************************************************************/
 package org.polarsys.capella.vp.mass.ju.testCase;
 

--- a/massviewpoint/tests/org.polarsys.capella.vp.mass.ju/src/org/polarsys/capella/vp/mass/ju/testCase/DeletePartMassBehaviorTest.java
+++ b/massviewpoint/tests/org.polarsys.capella.vp.mass.ju/src/org/polarsys/capella/vp/mass/ju/testCase/DeletePartMassBehaviorTest.java
@@ -1,0 +1,40 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Obeo
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License v1.0
+ *   which accompanies this distribution, and is available at
+ *   http://www.eclipse.org/legal/epl-v10.html
+ * 
+ *   Contributors:
+ *      OBEO - initial API and implementation
+ ******************************************************************************/
+package org.polarsys.capella.vp.mass.ju.testCase;
+
+import org.polarsys.capella.core.data.cs.impl.PartImpl;
+import org.polarsys.capella.core.data.pa.PhysicalComponent;
+import org.polarsys.capella.vp.mass.mass.impl.PartMassImpl;
+
+/**
+ * This test case checks if when deleting the partMass of a behavior PC the mass
+ * of its parents is re-calculated
+ */
+public class DeletePartMassBehaviorTest extends MassTest {
+
+	private PartMassImpl pc1PartMass;
+	private PhysicalComponent pc12;
+	private PartMassImpl pc12PartMass;
+
+	@Override
+	public void test() throws Exception {
+		PhysicalComponent pc1 = physicalSystem.getOwnedPhysicalComponents().get(0);
+		pc1PartMass = (PartMassImpl) ((PartImpl) pc1.getAbstractTypedElements().get(0)).getOwnedExtensions().get(0);
+		pc12 = pc1.getDeployedPhysicalComponents().get(0);
+		pc12PartMass = (PartMassImpl) ((PartImpl) pc12.getAbstractTypedElements().get(0)).getOwnedExtensions().get(0);
+
+		// remove pc1.2 and check if the mass of pc1 is re-calculated
+		deleteElement(pc12PartMass);
+		assertEquals("The mass of PC1 was not changed after the deletion of the part mass of PC 1.2",
+				pc1PartMass.getCurrentMass(), 75);
+	}
+
+}

--- a/massviewpoint/tests/org.polarsys.capella.vp.mass.ju/src/org/polarsys/capella/vp/mass/ju/testCase/DeletePartMassNodeTest.java
+++ b/massviewpoint/tests/org.polarsys.capella.vp.mass.ju/src/org/polarsys/capella/vp/mass/ju/testCase/DeletePartMassNodeTest.java
@@ -6,7 +6,7 @@
  *   http://www.eclipse.org/legal/epl-v10.html
  * 
  *   Contributors:
- *      OBEO - initial API and implementation
+ *      Obeo - initial API and implementation
  ******************************************************************************/
 package org.polarsys.capella.vp.mass.ju.testCase;
 

--- a/massviewpoint/tests/org.polarsys.capella.vp.mass.ju/src/org/polarsys/capella/vp/mass/ju/testCase/DeletePartMassNodeTest.java
+++ b/massviewpoint/tests/org.polarsys.capella.vp.mass.ju/src/org/polarsys/capella/vp/mass/ju/testCase/DeletePartMassNodeTest.java
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Obeo
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License v1.0
+ *   which accompanies this distribution, and is available at
+ *   http://www.eclipse.org/legal/epl-v10.html
+ * 
+ *   Contributors:
+ *      OBEO - initial API and implementation
+ ******************************************************************************/
+package org.polarsys.capella.vp.mass.ju.testCase;
+
+import org.polarsys.capella.core.data.cs.impl.PartImpl;
+import org.polarsys.capella.core.data.pa.PhysicalComponent;
+import org.polarsys.capella.vp.mass.mass.impl.PartMassImpl;
+
+/**
+ * This test case checks if when deleting a partMass of a node PC the mass of
+ * its parents is re-calculated
+ */
+public class DeletePartMassNodeTest extends MassTest {
+
+	private PartMassImpl pc1PartMass;
+	private PartMassImpl pc11PartMass;
+
+	@Override
+	public void test() throws Exception {
+		PhysicalComponent pc1 = physicalSystem.getOwnedPhysicalComponents().get(0);
+		pc1PartMass = (PartMassImpl) ((PartImpl) pc1.getAbstractTypedElements().get(0)).getOwnedExtensions().get(0);
+		PhysicalComponent pc11 = pc1.getOwnedPhysicalComponents().get(0);
+		pc11PartMass = (PartMassImpl) ((PartImpl) pc11.getAbstractTypedElements().get(0)).getOwnedExtensions().get(0);
+
+		// remove pc1.2 and check if the mass of pc1 is re-calculated
+		deleteElement(pc11PartMass);
+		assertEquals("The mass of PC1 was not changed after the deletion of the part mass of PC 1.1",
+				pc1PartMass.getCurrentMass(), 35);
+	}
+}

--- a/massviewpoint/tests/org.polarsys.capella.vp.mass.ju/src/org/polarsys/capella/vp/mass/ju/testCase/EditMassBehaviorTest.java
+++ b/massviewpoint/tests/org.polarsys.capella.vp.mass.ju/src/org/polarsys/capella/vp/mass/ju/testCase/EditMassBehaviorTest.java
@@ -6,7 +6,7 @@
  *   http://www.eclipse.org/legal/epl-v10.html
  * 
  *   Contributors:
- *      OBEO - initial API and implementation
+ *      Obeo - initial API and implementation
  ******************************************************************************/
 package org.polarsys.capella.vp.mass.ju.testCase;
 

--- a/massviewpoint/tests/org.polarsys.capella.vp.mass.ju/src/org/polarsys/capella/vp/mass/ju/testCase/EditMassBehaviorTest.java
+++ b/massviewpoint/tests/org.polarsys.capella.vp.mass.ju/src/org/polarsys/capella/vp/mass/ju/testCase/EditMassBehaviorTest.java
@@ -1,0 +1,42 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Obeo
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License v1.0
+ *   which accompanies this distribution, and is available at
+ *   http://www.eclipse.org/legal/epl-v10.html
+ * 
+ *   Contributors:
+ *      OBEO - initial API and implementation
+ ******************************************************************************/
+package org.polarsys.capella.vp.mass.ju.testCase;
+
+import org.polarsys.capella.core.data.cs.impl.PartImpl;
+import org.polarsys.capella.core.data.pa.PhysicalComponent;
+import org.polarsys.capella.vp.mass.mass.impl.PartMassImpl;
+
+/**
+ * This test case checks if when editing the mass of a behavior node the mass of
+ * its parents is re-calculated
+ */
+public class EditMassBehaviorTest extends MassTest {
+	PartMassImpl pc1PartMass;
+	PartMassImpl pc121PartMass;
+
+	@Override
+	public void test() throws Exception {
+		PhysicalComponent pc1 = physicalSystem.getOwnedPhysicalComponents().get(0);
+		pc1PartMass = (PartMassImpl) ((PartImpl) pc1.getAbstractTypedElements().get(0)).getOwnedExtensions().get(0);
+		PhysicalComponent pc12 = pc1.getDeployedPhysicalComponents().get(0);
+		PhysicalComponent pc121 = pc12.getDeployedPhysicalComponents().get(0);
+		pc121PartMass = (PartMassImpl) ((PartImpl) pc121.getAbstractTypedElements().get(0)).getOwnedExtensions().get(0);
+
+		// change the mass of pc1.2.1 (a behavior) and check if the mass of pc1 is
+		// re-calculated
+		editMassPhysicalComponent(pc121, 10);
+		assertEquals("The mass of PC1.2.1 was not changed after its modification", pc121PartMass.getCurrentMass(), 10);
+		assertEquals("The mass of PC1 was not changed after the modification of pc1.2.1", pc1PartMass.getCurrentMass(),
+				90);
+
+	}
+
+}

--- a/massviewpoint/tests/org.polarsys.capella.vp.mass.ju/src/org/polarsys/capella/vp/mass/ju/testCase/EditMassNodeTest.java
+++ b/massviewpoint/tests/org.polarsys.capella.vp.mass.ju/src/org/polarsys/capella/vp/mass/ju/testCase/EditMassNodeTest.java
@@ -6,7 +6,7 @@
  *   http://www.eclipse.org/legal/epl-v10.html
  * 
  *   Contributors:
- *      OBEO - initial API and implementation
+ *      Obeo - initial API and implementation
  ******************************************************************************/
 package org.polarsys.capella.vp.mass.ju.testCase;
 

--- a/massviewpoint/tests/org.polarsys.capella.vp.mass.ju/src/org/polarsys/capella/vp/mass/ju/testCase/EditMassNodeTest.java
+++ b/massviewpoint/tests/org.polarsys.capella.vp.mass.ju/src/org/polarsys/capella/vp/mass/ju/testCase/EditMassNodeTest.java
@@ -1,0 +1,41 @@
+/*******************************************************************************
+ * Copyright (c) 2006, 2020 Obeo
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License v1.0
+ *   which accompanies this distribution, and is available at
+ *   http://www.eclipse.org/legal/epl-v10.html
+ * 
+ *   Contributors:
+ *      OBEO - initial API and implementation
+ ******************************************************************************/
+package org.polarsys.capella.vp.mass.ju.testCase;
+
+import org.polarsys.capella.core.data.cs.impl.PartImpl;
+import org.polarsys.capella.core.data.pa.PhysicalComponent;
+import org.polarsys.capella.vp.mass.mass.impl.PartMassImpl;
+
+/**
+ * This test case checks if when editing the mass of a node the mass of its
+ * parents is re-calculated
+ */
+public class EditMassNodeTest extends MassTest {
+	PartMassImpl pc1PartMass;
+	PartMassImpl pc11PartMass;
+
+	@Override
+	public void test() throws Exception {
+		PhysicalComponent pc1 = physicalSystem.getOwnedPhysicalComponents().get(0);
+		pc1PartMass = (PartMassImpl) ((PartImpl) pc1.getAbstractTypedElements().get(0)).getOwnedExtensions().get(0);
+		PhysicalComponent pc11 = pc1.getOwnedPhysicalComponents().get(0);
+		pc11PartMass = (PartMassImpl) ((PartImpl) pc11.getAbstractTypedElements().get(0)).getOwnedExtensions().get(0);
+
+		// change the mass of pc1.1 (a node) and check if the mass of pc1 is
+		// re-calculated
+		editMassPhysicalComponent(pc11, 40);
+		assertEquals("The mass of PC1.1 was not changed after its modification", pc11PartMass.getCurrentMass(), 40);
+		assertEquals("The mass of PC1 was not changed after the modification of pc1.1", pc1PartMass.getCurrentMass(),
+				75);
+
+	}
+
+}

--- a/massviewpoint/tests/org.polarsys.capella.vp.mass.ju/src/org/polarsys/capella/vp/mass/ju/testCase/MassCalculatedOpeningSessionTest.java
+++ b/massviewpoint/tests/org.polarsys.capella.vp.mass.ju/src/org/polarsys/capella/vp/mass/ju/testCase/MassCalculatedOpeningSessionTest.java
@@ -6,7 +6,7 @@
  *   http://www.eclipse.org/legal/epl-v10.html
  * 
  *   Contributors:
- *      OBEO - initial API and implementation
+ *      Obeo - initial API and implementation
  ******************************************************************************/
 package org.polarsys.capella.vp.mass.ju.testCase;
 

--- a/massviewpoint/tests/org.polarsys.capella.vp.mass.ju/src/org/polarsys/capella/vp/mass/ju/testCase/MassCalculatedOpeningSessionTest.java
+++ b/massviewpoint/tests/org.polarsys.capella.vp.mass.ju/src/org/polarsys/capella/vp/mass/ju/testCase/MassCalculatedOpeningSessionTest.java
@@ -1,0 +1,56 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Obeo
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License v1.0
+ *   which accompanies this distribution, and is available at
+ *   http://www.eclipse.org/legal/epl-v10.html
+ * 
+ *   Contributors:
+ *      OBEO - initial API and implementation
+ ******************************************************************************/
+package org.polarsys.capella.vp.mass.ju.testCase;
+
+import org.junit.Test;
+import org.polarsys.capella.core.data.cs.impl.PartImpl;
+import org.polarsys.capella.core.data.pa.PhysicalComponent;
+import org.polarsys.capella.vp.mass.mass.impl.PartMassImpl;
+
+/**
+ * This test makes sure the mass of all the elements are correctly calculated
+ * when opening a new session
+ */
+public class MassCalculatedOpeningSessionTest extends MassTest {
+	PartMassImpl pc1PartMass;
+	PartMassImpl pc11PartMass;
+	PartMassImpl pc12PartMass;
+	PartMassImpl pc121PartMass;
+
+	@Test
+	public void test() {
+
+		// fetch pc1 and check if its mass is correct
+		PhysicalComponent pc1 = physicalSystem.getOwnedPhysicalComponents().get(0);
+		assertNotNull("PC1 could not be retrieved", pc1);
+		pc1PartMass = (PartMassImpl) ((PartImpl) pc1.getAbstractTypedElements().get(0)).getOwnedExtensions().get(0);
+		assertEquals("The mass of PC1 is incorrect", pc1PartMass.getCurrentMass(), 85);
+
+		// fetch pc1.1 and check if its mass is correct
+		PhysicalComponent pc11 = pc1.getOwnedPhysicalComponents().get(0);
+		assertNotNull("PC1.1 could not be retrieved", pc11);
+		pc11PartMass = (PartMassImpl) ((PartImpl) pc11.getAbstractTypedElements().get(0)).getOwnedExtensions().get(0);
+		assertEquals("The mass of PC1.1 is incorrect", pc11PartMass.getCurrentMass(), 50);
+
+		// fetch pc1.2 and check if its mass is correct
+		PhysicalComponent pc12 = pc1.getDeployedPhysicalComponents().get(0);
+		assertNotNull("PC1.2 could not be retrieved", pc12);
+		pc12PartMass = (PartMassImpl) ((PartImpl) pc12.getAbstractTypedElements().get(0)).getOwnedExtensions().get(0);
+		assertEquals("The mass of PC1.2 is incorrect", pc12PartMass.getCurrentMass(), 15);
+
+		// fetch pc1.2.1 and check if its mass is correct
+		PhysicalComponent pc121 = pc12.getDeployedPhysicalComponents().get(0);
+		assertNotNull("PC1.2.1 could not be retrieved", pc121);
+		pc121PartMass = (PartMassImpl) ((PartImpl) pc121.getAbstractTypedElements().get(0)).getOwnedExtensions().get(0);
+		assertEquals("The mass of PC1.2.1 is incorrect", pc121PartMass.getCurrentMass(), 5);
+	}
+
+}

--- a/massviewpoint/tests/org.polarsys.capella.vp.mass.ju/src/org/polarsys/capella/vp/mass/ju/testCase/MassTest.java
+++ b/massviewpoint/tests/org.polarsys.capella.vp.mass.ju/src/org/polarsys/capella/vp/mass/ju/testCase/MassTest.java
@@ -6,7 +6,7 @@
  *   http://www.eclipse.org/legal/epl-v10.html
  * 
  *   Contributors:
- *      OBEO - initial API and implementation
+ *      Obeo - initial API and implementation
  ******************************************************************************/
 package org.polarsys.capella.vp.mass.ju.testCase;
 

--- a/massviewpoint/tests/org.polarsys.capella.vp.mass.ju/src/org/polarsys/capella/vp/mass/ju/testCase/MassTest.java
+++ b/massviewpoint/tests/org.polarsys.capella.vp.mass.ju/src/org/polarsys/capella/vp/mass/ju/testCase/MassTest.java
@@ -1,0 +1,145 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Obeo
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License v1.0
+ *   which accompanies this distribution, and is available at
+ *   http://www.eclipse.org/legal/epl-v10.html
+ * 
+ *   Contributors:
+ *      OBEO - initial API and implementation
+ ******************************************************************************/
+package org.polarsys.capella.vp.mass.ju.testCase;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.eclipse.core.runtime.jobs.Job;
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.sirius.business.api.session.Session;
+import org.eclipse.ui.internal.Workbench;
+import org.polarsys.capella.common.data.modellingcore.ModelElement;
+import org.polarsys.capella.common.ef.ExecutionManager;
+import org.polarsys.capella.common.ef.command.AbstractReadWriteCommand;
+import org.polarsys.capella.common.helpers.TransactionHelper;
+import org.polarsys.capella.core.data.capellamodeller.Project;
+import org.polarsys.capella.core.data.capellamodeller.SystemEngineering;
+import org.polarsys.capella.core.data.cs.impl.PartImpl;
+import org.polarsys.capella.core.data.pa.PhysicalArchitecture;
+import org.polarsys.capella.core.data.pa.PhysicalComponent;
+import org.polarsys.capella.core.data.pa.PhysicalComponentPkg;
+import org.polarsys.capella.core.libraries.model.CapellaModel;
+import org.polarsys.capella.core.libraries.utils.ScopeModelWrapper;
+import org.polarsys.capella.core.platform.sirius.ui.commands.CapellaDeleteCommand;
+import org.polarsys.capella.shared.id.handler.IScope;
+import org.polarsys.capella.shared.id.handler.IdManager;
+import org.polarsys.capella.test.framework.api.BasicTestCase;
+import org.polarsys.capella.vp.mass.helpers.MassCreationToolHelper;
+import org.polarsys.capella.vp.mass.mass.impl.PartMassImpl;
+
+/**
+ * Implements methods often used by mass test cases
+ */
+public abstract class MassTest extends BasicTestCase {
+	protected PhysicalComponent physicalSystem;
+	public static final String MODEL_NAME = "MassProject";
+
+	@Override
+	public List<String> getRequiredTestModels() {
+		return Arrays.asList(MODEL_NAME);
+	}
+
+	@SuppressWarnings("restriction")
+	protected void setUp() throws Exception {
+		super.setUp();
+		// Deadlock because of Workbench Auto-Save Job, so we have to remove it
+		Job[] allJobs = Job.getJobManager().find(null);
+		for (Job job : allJobs) {
+			if (Workbench.WORKBENCH_AUTO_SAVE_JOB.equals(job.getName())) {
+				job.cancel();
+			}
+		}
+		physicalSystem = getPhysicalSystem();
+	}
+
+	/**
+	 * Retrieves the PhysicalComponent root of the Physical Architecture part of a
+	 * capella model
+	 * 
+	 * @return the PhysicalSystem component from a model
+	 */
+	protected PhysicalComponent getPhysicalSystem() {
+		// fetch the root element
+		CapellaModel model = getTestModel(getRequiredTestModels().get(0));
+		Session session = getSession(getRequiredTestModels().get(0));
+		Project project = model.getProject(session.getTransactionalEditingDomain());
+		SystemEngineering eng = ((SystemEngineering) (project.getOwnedModelRoots().get(0)));
+		PhysicalArchitecture physicalArchi = (PhysicalArchitecture) eng.getOwnedArchitectures().get(3);
+		PhysicalComponentPkg physicalComponentPkg = physicalArchi.getOwnedPhysicalComponentPkg();
+		return physicalComponentPkg.getOwnedPhysicalComponents().get(0);
+	}
+
+	/**
+	 * Delete an element of a capella model
+	 * @param the element to delete
+	 */
+	protected void deleteElement(ModelElement element) {
+		ExecutionManager manager = TransactionHelper.getExecutionManager(element);
+		manager.execute(new AbstractReadWriteCommand() {
+
+			@Override
+			public void run() {
+				CapellaModel model = getTestModel(getRequiredTestModels().get(0));
+				IScope scope = new ScopeModelWrapper(model);
+				EObject object = IdManager.getInstance().getEObject(((ModelElement) element).getId(), scope);
+				CapellaDeleteCommand command = new CapellaDeleteCommand(TransactionHelper.getExecutionManager(object),
+						Collections.singletonList(object), true, false, true);
+				if (command.canExecute()) {
+					command.execute();
+				} else {
+					assertTrue("cannot remove an element", false);
+				}
+			}
+		});
+	}
+
+	/**
+	 * Add a PartMass to a PhysicalComponent
+	 * @param element the element we wish to add a mass to
+	 * @param massValue the value of the mass
+	 */
+	protected void addMassToPhysicalComponent(PhysicalComponent element, int massValue) {
+		ExecutionManager manager = TransactionHelper.getExecutionManager(element);
+		manager.execute(new AbstractReadWriteCommand() {
+
+			@Override
+			public void run() {
+				MassCreationToolHelper massCreationToolHelper = new MassCreationToolHelper();
+				massCreationToolHelper.createMass(element, 1);
+				PartMassImpl elementPartMass = (PartMassImpl) ((PartImpl) element.getAbstractTypedElements().get(0))
+						.getOwnedExtensions().get(0);
+				elementPartMass.setValue(massValue);
+			}
+
+		});
+	}
+
+	/**
+	 * Change the value of the PartMass of a PhysicalComponent
+	 * @param element the element we wish to change the mass
+	 * @param newMass the new value of the mass
+	 */
+	protected void editMassPhysicalComponent(PhysicalComponent element, int newMass) {
+		PartMassImpl pcPartMass = (PartMassImpl) ((PartImpl) element.getAbstractTypedElements().get(0))
+				.getOwnedExtensions().get(0);
+		ExecutionManager managerpc = TransactionHelper.getExecutionManager(element);
+		managerpc.execute(new AbstractReadWriteCommand() {
+
+			@Override
+			public void run() {
+				pcPartMass.setValue(newMass);
+			}
+		});
+	}
+
+}

--- a/massviewpoint/tests/pom.xml
+++ b/massviewpoint/tests/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright (c) 2020 OBEO
+  Copyright (c) 2020 Obeo
   All rights reserved. This program and the accompanying materials
   are made available under the terms of the Eclipse Public License v1.0
   which accompanies this distribution, and is available at

--- a/massviewpoint/tests/pom.xml
+++ b/massviewpoint/tests/pom.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright (c) 2020 OBEO
+  All rights reserved. This program and the accompanying materials
+  are made available under the terms of the Eclipse Public License v1.0
+  which accompanies this distribution, and is available at
+  http://www.eclipse.org/legal/epl-v10.html
+
+  Contributors:
+       Obeo - initial API and implementation
+-->
+<project
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+	xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>org.polarsys</groupId>
+	<artifactId>org.polarsys.capella.basic.mass.viewpoint.tests</artifactId>
+	<packaging>pom</packaging>
+
+	<parent>
+		<groupId>org.polarsys</groupId>
+		<artifactId>org.polarsys.capella.addon.basic.viewpoints</artifactId>
+		<version>1.4.0-SNAPSHOT</version>
+		<relativePath>../../</relativePath>
+	</parent>
+
+	<modules>
+		<module>org.polarsys.capella.vp.mass.ju</module>
+	</modules>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright (c) 2017, 2019 THALES GLOBAL SERVICES.
+  Copyright (c) 2017, 20120 THALES GLOBAL SERVICES.
   All rights reserved. This program and the accompanying materials
   are made available under the terms of the Eclipse Public License v1.0
   which accompanies this distribution, and is available at
@@ -8,6 +8,7 @@
 
   Contributors:
        Thales - initial API and implementation
+       Obeo - add mass test profile
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
@@ -24,8 +25,8 @@
 	<packaging>pom</packaging>
 
 	<properties>
-		<tycho-version>1.1.0</tycho-version>
-		<tycho-extras-version>1.1.0</tycho-extras-version>
+		<tycho-version>1.6.0</tycho-version>
+		<tycho-extras-version>1.6.0</tycho-extras-version>
 		<tycho.scmUrl>scm:git:http://git.polarsys.org/c/capella/capella-basic-vp.git</tycho.scmUrl>
 		<antrun-version>1.7</antrun-version>
 		<sonar-version>3.0.2</sonar-version>
@@ -36,6 +37,8 @@
 		
 		<!-- for junit -->
 		<capella-product-id>org.polarsys.capella.core.platform.sirius.ui.perspective.product</capella-product-id>
+		<capella-rcp-product-id>org.polarsys.capella.rcp.product</capella-rcp-product-id>
+		<capella-application-id>org.polarsys.capella.core.platform.sirius.ui.perspective.id</capella-application-id>
 		<tycho.testArgLine>-Xms256m -Xmx1024m</tycho.testArgLine>
 
 		<!-- for packaging -->
@@ -80,6 +83,18 @@
 				<module>priceviewpoint/features</module>
 				<module>priceviewpoint/plugins</module>
 				<module>releng/org.polarsys.capella.basic.price.viewpoint.site</module>
+			</modules>
+		</profile>
+		<profile>
+			<id>massTests</id>
+			<activation>
+				<activeByDefault>false</activeByDefault>
+			</activation>
+			<modules>
+				<module>massviewpoint/tests</module>
+				<module>massviewpoint/features</module>
+				<module>massviewpoint/plugins</module>
+				<module>releng/org.polarsys.capella.basic.mass.viewpoint.site</module>
 			</modules>
 		</profile>
 	</profiles>

--- a/releng/org.polarsys.capella.basic.viewpoints.target/tp/capella.target-definition.target
+++ b/releng/org.polarsys.capella.basic.viewpoints.target/tp/capella.target-definition.target
@@ -1,27 +1,30 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde?>
 <!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl -->
-<target name="CapellaBasicViewpoints" sequenceNumber="1579548718">
+<target name="CapellaBasicViewpoints" sequenceNumber="1583835740">
   <locations>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
-      <unit id="org.eclipse.gmf.runtime.notation.feature.group" version="0.0.0"/>
+      <unit id="org.eclipse.gmf.runtime.notation.source.feature.group" version="0.0.0"/>
       <repository id="GMF-Notation-1.12rc1" location="http://download.eclipse.org/modeling/gmp/gmf-notation/updates/milestones/S201805221301"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
-      <unit id="org.eclipse.gmf.feature.group" version="0.0.0"/>
+      <unit id="org.eclipse.gmf.source.feature.group" version="0.0.0"/>
+      <unit id="org.eclipse.gmf.runtime.thirdparty.source.feature.group" version="0.0.0"/>
       <repository id="GMF-Runtime-1.12rc3" location="http://download.eclipse.org/modeling/gmp/gmf-runtime/updates/milestones/S201806010809"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.sdk.feature.group" version="4.12.0.v20190605-1801"/>
       <unit id="org.eclipse.platform.feature.group" version="4.12.0.v20190605-1801"/>
+      <unit id="org.eclipse.draw2d.source.feature.group" version="3.10.100.201606061308"/>
       <unit id="org.eclipse.emf.sdk.feature.group" version="2.18.0.v20190528-0845"/>
-      <unit id="org.eclipse.emf.transaction.feature.group" version="1.12.0.201805140824"/>
+      <unit id="org.eclipse.emf.validation.source.feature.group" version="1.12.1.201812070911"/>
+      <unit id="org.eclipse.emf.transaction.source.feature.group" version="1.12.0.201805140824"/>
+      <unit id="org.eclipse.emf.workspace.source.feature.group" version="1.12.0.201805140824"/>
+      <unit id="org.eclipse.gef.source.feature.group" version="3.11.0.201606061308"/>
       <unit id="org.eclipse.equinox.executable.feature.group" version="3.8.400.v20190515-0925"/>
       <unit id="com.ibm.icu" version="64.2.0.v20190507-1337"/>
       <unit id="org.eclipse.viatra.query.sdk.feature.source.feature.group" version="2.2.0.201906120939"/>
-      <unit id="org.eclipse.jgit.feature.group" version="5.4.0.201906121030-r"/>
       <unit id="org.eclipse.jgit.source.feature.group" version="5.4.0.201906121030-r"/>
-      <unit id="org.eclipse.egit.feature.group" version="5.4.0.201906121030-r"/>
       <unit id="org.eclipse.egit.source.feature.group" version="5.4.0.201906121030-r"/>
       <unit id="org.eclipse.mylyn_feature.feature.group" version="3.24.2.v20180905-0003"/>
       <unit id="org.eclipse.mylyn.commons.feature.group" version="3.24.2.v20180904-2231"/>
@@ -34,90 +37,60 @@
       <repository id="eclipse" location="http://download.eclipse.org/releases/2019-06"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
-      <unit id="org.eclipse.sirius.doc.feature.feature.group" version="6.3.0.201910180815"/>
-      <unit id="org.eclipse.sirius.doc.feature.source.feature.group" version="6.3.0.201910180815"/>
-      <unit id="org.eclipse.sirius.runtime.feature.group" version="6.3.0.201910180815"/>
-      <unit id="org.eclipse.sirius.runtime.source.feature.group" version="6.3.0.201910180815"/>
-      <unit id="org.eclipse.sirius.runtime.aql.feature.group" version="6.3.0.201910180815"/>
-      <unit id="org.eclipse.sirius.runtime.aql.source.feature.group" version="6.3.0.201910180815"/>
-      <unit id="org.eclipse.sirius.runtime.ide.ui.feature.group" version="6.3.0.201910180815"/>
-      <unit id="org.eclipse.sirius.runtime.ide.ui.source.feature.group" version="6.3.0.201910180815"/>
-      <unit id="org.eclipse.sirius.interpreter.feature.feature.group" version="6.3.0.201910180815"/>
-      <unit id="org.eclipse.sirius.interpreter.feature.source.feature.group" version="6.3.0.201910180815"/>
-      <unit id="org.eclipse.acceleo.ui.interpreter.feature.group" version="3.7.8.201902261618"/>
+      <unit id="org.eclipse.sirius.doc.feature.source.feature.group" version="6.3.1.202001141527"/>
+      <unit id="org.eclipse.sirius.runtime.source.feature.group" version="6.3.1.202001141527"/>
+      <unit id="org.eclipse.sirius.runtime.aql.source.feature.group" version="6.3.1.202001141527"/>
+      <unit id="org.eclipse.sirius.runtime.ide.ui.source.feature.group" version="6.3.1.202001141527"/>
+      <unit id="org.eclipse.sirius.interpreter.feature.source.feature.group" version="6.3.1.202001141527"/>
       <unit id="org.eclipse.acceleo.ui.interpreter.source.feature.group" version="3.7.8.201902261618"/>
-      <unit id="org.eclipse.sirius.aql.feature.group" version="6.3.0.201910180815"/>
-      <unit id="org.eclipse.sirius.aql.source.feature.group" version="6.3.0.201910180815"/>
-      <unit id="org.eclipse.acceleo.query.feature.group" version="6.0.8.201902261618"/>
+      <unit id="org.eclipse.sirius.aql.source.feature.group" version="6.3.1.202001141527"/>
       <unit id="org.eclipse.acceleo.query.source.feature.group" version="6.0.8.201902261618"/>
-      <unit id="org.eclipse.sirius.runtime.ide.ui.acceleo.feature.group" version="6.3.0.201910180815"/>
-      <unit id="org.eclipse.sirius.runtime.ide.ui.acceleo.source.feature.group" version="6.3.0.201910180815"/>
-      <repository id="sirius" location="https://download.eclipse.org/sirius/updates/milestones/6.3.0rc1/2019-06/"/>
+      <unit id="org.eclipse.sirius.runtime.ide.ui.acceleo.source.feature.group" version="6.3.1.202001141527"/>
+      <repository id="sirius" location="https://download.eclipse.org/sirius/updates/stable/6.3.1-S20200114-102549/2019-06/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
-      <unit id="org.polarsys.kitalpha.ad.runtime.feature.feature.group" version="1.4.0.202001100637"/>
-      <unit id="org.polarsys.kitalpha.cadence.feature.feature.group" version="1.4.0.202001100637"/>
-      <unit id="org.polarsys.kitalpha.common.feature.feature.group" version="1.4.0.202001100637"/>
-      <unit id="org.polarsys.kitalpha.emde.feature.feature.group" version="1.4.0.202001100637"/>
-      <unit id="org.polarsys.kitalpha.emde.ui.feature.feature.group" version="1.4.0.202001100637"/>
-      <unit id="org.polarsys.kitalpha.massactions.feature.feature.group" version="1.4.0.202001100637"/>
+      <unit id="org.polarsys.kitalpha.ad.runtime.feature.source.feature.group" version="1.4.0.202001100637"/>
+      <unit id="org.polarsys.kitalpha.cadence.feature.source.feature.group" version="1.4.0.202001100637"/>
+      <unit id="org.polarsys.kitalpha.common.feature.source.feature.group" version="1.4.0.202001100637"/>
+      <unit id="org.polarsys.kitalpha.emde.feature.source.feature.group" version="1.4.0.202001100637"/>
+      <unit id="org.polarsys.kitalpha.emde.ui.feature.source.feature.group" version="1.4.0.202001100637"/>
       <unit id="org.polarsys.kitalpha.massactions.feature.source.feature.group" version="1.4.0.202001100637"/>
-      <unit id="org.polarsys.kitalpha.model.common.share.feature.feature.group" version="1.4.0.202001100637"/>
-      <unit id="org.polarsys.kitalpha.model.common.commands.feature.feature.group" version="1.4.0.202001100637"/>
-      <unit id="org.polarsys.kitalpha.model.common.scrutiny.feature.feature.group" version="1.4.0.202001100637"/>
-      <unit id="org.polarsys.kitalpha.model.detachment.contrib.viewpoints.feature.feature.group" version="1.4.0.202001100637"/>
-      <unit id="org.polarsys.kitalpha.model.detachment.feature.feature.group" version="1.4.0.202001100637"/>
-      <unit id="org.polarsys.kitalpha.model.detachment.ui.feature.feature.group" version="1.4.0.202001100637"/>
-      <unit id="org.polarsys.kitalpha.patterns.feature.feature.group" version="1.4.0.202001100637"/>
-      <unit id="org.polarsys.kitalpha.report.feature.feature.group" version="1.4.0.202001100637"/>
-      <unit id="org.polarsys.kitalpha.report.ui.feature.feature.group" version="1.4.0.202001100637"/>
-      <unit id="org.polarsys.kitalpha.resourcereuse.emfscheme.feature.feature.group" version="1.4.0.202001100637"/>
-      <unit id="org.polarsys.kitalpha.resourcereuse.emfscheme.ui.feature.feature.group" version="1.4.0.202001100637"/>
-      <unit id="org.polarsys.kitalpha.resourcereuse.feature.feature.group" version="1.4.0.202001100637"/>
-      <unit id="org.polarsys.kitalpha.resourcereuse.ui.feature.feature.group" version="1.4.0.202001100637"/>
-      <unit id="org.polarsys.kitalpha.richtext.widget.feature.feature.group" version="1.4.0.202001100637"/>
+      <unit id="org.polarsys.kitalpha.model.common.share.feature.source.feature.group" version="1.4.0.202001100637"/>
+      <unit id="org.polarsys.kitalpha.model.common.commands.feature.source.feature.group" version="1.4.0.202001100637"/>
+      <unit id="org.polarsys.kitalpha.model.common.scrutiny.feature.source.feature.group" version="1.4.0.202001100637"/>
+      <unit id="org.polarsys.kitalpha.model.detachment.contrib.viewpoints.feature.source.feature.group" version="1.4.0.202001100637"/>
+      <unit id="org.polarsys.kitalpha.model.detachment.feature.source.feature.group" version="1.4.0.202001100637"/>
+      <unit id="org.polarsys.kitalpha.model.detachment.ui.feature.source.feature.group" version="1.4.0.202001100637"/>
+      <unit id="org.polarsys.kitalpha.report.feature.source.feature.group" version="1.4.0.202001100637"/>
+      <unit id="org.polarsys.kitalpha.report.ui.feature.source.feature.group" version="1.4.0.202001100637"/>
+      <unit id="org.polarsys.kitalpha.resourcereuse.emfscheme.feature.source.feature.group" version="1.4.0.202001100637"/>
+      <unit id="org.polarsys.kitalpha.resourcereuse.emfscheme.ui.feature.source.feature.group" version="1.4.0.202001100637"/>
+      <unit id="org.polarsys.kitalpha.resourcereuse.feature.source.feature.group" version="1.4.0.202001100637"/>
+      <unit id="org.polarsys.kitalpha.resourcereuse.ui.feature.source.feature.group" version="1.4.0.202001100637"/>
       <unit id="org.polarsys.kitalpha.richtext.widget.feature.source.feature.group" version="1.4.0.202001100637"/>
-      <unit id="org.polarsys.kitalpha.richtext.widget.ext.feature.feature.group" version="1.4.0.202001100637"/>
       <unit id="org.polarsys.kitalpha.richtext.widget.ext.feature.source.feature.group" version="1.4.0.202001100637"/>
-      <unit id="org.polarsys.kitalpha.transposer.feature.feature.group" version="1.4.0.202001100637"/>
-      <repository id="kitalpha-runtime-core-master" location="https://download.eclipse.org/kitalpha/updates/stable/runtimecore/1.4.0.202001100637"/>
+      <unit id="org.polarsys.kitalpha.transposer.feature.source.feature.group" version="1.4.0.202001100637"/>
+      <repository id="kitalpha-runtimecore" location="https://download.eclipse.org/kitalpha/updates/stable/runtimecore/1.4.0.202001100637"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.polarsys.kitalpha.doc.feature.feature.group" version="1.4.0.202001100637"/>
-      <unit id="org.polarsys.kitalpha.emde.sdk.feature.feature.group" version="1.4.0.202001100637"/>
-      <repository id="kitalpha-sdk-master" location="https://download.eclipse.org/kitalpha/updates/stable/sdk/1.4.0.202001100637/"/>
+      <unit id="org.polarsys.kitalpha.emde.sdk.feature.source.feature.group" version="1.4.0.202001100637"/>
+      <repository id="kitalpha-sdk" location="https://download.eclipse.org/kitalpha/updates/stable/sdk/1.4.0.202001100637/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
-      <unit id="org.eclipse.emf.diffmerge.feature.feature.group" version="0.12.0.201910020901"/>
       <unit id="org.eclipse.emf.diffmerge.feature.source.feature.group" version="0.12.0.201910020901"/>
-      <unit id="org.eclipse.emf.diffmerge.sirius.feature.feature.group" version="0.12.0.201910020901"/>
       <unit id="org.eclipse.emf.diffmerge.sirius.feature.source.feature.group" version="0.12.0.201910020901"/>
-      <unit id="org.eclipse.emf.diffmerge.gmf.feature.feature.group" version="0.12.0.201910020901"/>
       <unit id="org.eclipse.emf.diffmerge.gmf.feature.source.feature.group" version="0.12.0.201910020901"/>
-      <unit id="org.eclipse.emf.diffmerge.sdk.feature.feature.group" version="0.12.0.201910020901"/>
-      <unit id="org.eclipse.emf.diffmerge.egit.feature.feature.group" version="0.12.0.201910020901"/>
+      <unit id="org.eclipse.emf.diffmerge.sdk.feature.source.feature.group" version="0.12.0.201910020901"/>
       <unit id="org.eclipse.emf.diffmerge.egit.feature.source.feature.group" version="0.12.0.201910020901"/>
-      <repository id="diffmerge-core-master" location="https://download.eclipse.org/diffmerge/releases/0.12.0/emf-diffmerge-site"/>
+      <repository id="diffmerge-core" location="https://download.eclipse.org/diffmerge/releases/0.12.0/emf-diffmerge-site"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
-      <unit id="org.eclipse.emf.diffmerge.patterns.sdk.feature.feature.group" version="0.12.0.201910020911"/>
-      <unit id="org.eclipse.emf.diffmerge.patterns.sdk.feature.source.feature.group" version="0.12.0.201910020911"/>
-      <unit id="org.eclipse.emf.diffmerge.patterns.sirius.sdk.feature.feature.group" version="0.12.0.201910020911"/>
-      <unit id="org.eclipse.emf.diffmerge.patterns.sirius.sdk.feature.source.feature.group" version="0.12.0.201910020911"/>
-      <repository id="diffmerge-patterns-master" location="https://download.eclipse.org/diffmerge/releases/0.12.0/edm-patterns-site"/>
-    </location>
-    <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
-      <unit id="org.eclipse.amalgam.explorer.activity.feature.group" version="1.11.0.201910071427"/>
       <unit id="org.eclipse.amalgam.explorer.activity.source.feature.group" version="1.11.0.201910071427"/>
       <repository id="amalgam" location="https://download.eclipse.org/modeling/amalgam/updates/stable/1.11.0-S20191007/capella"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
-      <unit id="org.eclipse.sirius.query.legacy.feature.feature.group" version="1.1.0.201504271341"/>
-      <unit id="org.eclipse.sirius.query.legacy.feature.source.feature.group" version="1.1.0.201504271341"/>
-      <repository id="sirius-query-legacy" location="http://download.eclipse.org/sirius/updates/legacy/1.1.0"/>
-    </location>
-    <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
-      <unit id="org.eclipse.egf.sdk.feature.feature.group" version="1.6.1.201906060805"/>
+      <unit id="org.eclipse.egf.sdk.feature.source.feature.group" version="1.6.1.201906060805"/>
       <repository id="egf" location="http://download.eclipse.org/egf/updates/1.6.1/2019-06/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
@@ -129,19 +102,28 @@
       <repository id="eclipse-shared-license" location="http://download.eclipse.org/cbi/updates/license"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
-      <unit id="org.apache.log4j" version="1.2.15.v201012070815"/>
-      <unit id="org.apache.commons.lang" version="2.4.0.v201005080502"/>
-      <unit id="org.apache.commons.net" version="3.2.0.v201305141515"/>
       <unit id="org.jsoup" version="1.7.2.v201304221138"/>
-      <repository id="orbit-R20130827064939" location="http://download.eclipse.org/tools/orbit/downloads/drops/R20130827064939/repository"/>
-    </location>
-    <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
+      <unit id="org.apache.commons.net" version="3.2.0.v201305141515"/>
+      <unit id="org.apache.commons.lang" version="2.4.0.v201005080502"/>
+      <unit id="org.apache.log4j" version="1.2.15.v201012070815"/>
       <unit id="com.google.guava" version="15.0.0.v201403281430"/>
       <repository id="orbit-R20140525021250" location="http://download.eclipse.org/tools/orbit/downloads/drops/R20140525021250/repository"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.polarsys.capella.rcp.feature.feature.group" version="0.0.0"/>
-      <repository id="capella-master" location="https://download.eclipse.org/capella/core/updates/nightly/master/org.polarsys.capella.rcp.site/"/>
+      <repository id="capella-master" location="https://download.eclipse.org/capella/core/updates/releases/1.4.0-R20191121-173601/org.polarsys.capella.rcp.site/"/>
+    </location>
+    <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
+      <unit id="org.polarsys.capella.test.framework" version="0.0.0"/>
+      <repository id="capella-test" location="https://download.eclipse.org/capella/core/updates/releases/1.4.0-R20191121-173601/org.polarsys.capella.test.site/"/>
+    </location>
+    <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
+      <unit id="org.eclipse.emf.diffmerge.patterns.templates.gen" version="0.0.0"/>
+      <repository id="diffmerge-pattern" location="https://download.eclipse.org/diffmerge/releases/0.12.0/edm-patterns-site/"/>
+    </location>
+    <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
+      <unit id="org.eclipse.sirius.query.legacy" version="0.0.0"/>
+      <repository id="sirius-query-legacy" location="https://download.eclipse.org/sirius/updates/legacy/"/>
     </location>
   </locations>
 </target>

--- a/releng/org.polarsys.capella.basic.viewpoints.target/tp/capella.target-definition.targetplatform
+++ b/releng/org.polarsys.capella.basic.viewpoints.target/tp/capella.target-definition.targetplatform
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c)  2017, 2018 THALES GLOBAL SERVICES.
+ * Copyright (c)  2017, 2020 THALES GLOBAL SERVICES.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -7,13 +7,26 @@
  *
  * Contributors:
  *    Thales - initial API and implementation
+ * 	  Obeo - add tests location
  *******************************************************************************/
 target "CapellaBasicViewpoints"
 
 include "https://github.com/eclipse/capella/raw/master/releng/plugins/org.polarsys.capella.targets/full/capella.target-definition.targetplatform"
 
 with source, requirements
-
-location capella-master "https://download.eclipse.org/capella/core/updates/nightly/master/org.polarsys.capella.rcp.site/" {
+location capella-master "https://download.eclipse.org/capella/core/updates/releases/1.4.0-R20191121-173601/org.polarsys.capella.rcp.site/" {
 	org.polarsys.capella.rcp.feature.feature.group lazy
+}
+
+//following locations are used for tests
+location capella-test "https://download.eclipse.org/capella/core/updates/releases/1.4.0-R20191121-173601/org.polarsys.capella.test.site/" {
+	org.polarsys.capella.test.framework lazy
+}
+
+location diffmerge-pattern "https://download.eclipse.org/diffmerge/releases/0.12.0/edm-patterns-site/" {
+	org.eclipse.emf.diffmerge.patterns.templates.gen lazy
+}
+
+location sirius-query-legacy "https://download.eclipse.org/sirius/updates/legacy/" {
+	org.eclipse.sirius.query.legacy lazy
 }


### PR DESCRIPTION
### Problem
Mass computations for each element of the diagram are called from a conditional style in the odesign file. This means that every time the view is refreshed, the mass of every element of the diagram is re-calculated, leading to performance issues on bigger diagrams.

### Solution
I provide a modification relying on a pre-commit listener on the resource manager of the session to trigger mass computations. This listener is only triggered when adding a mass to the model, editing the mass of an element, moving an element with a mass, or removing an element with a mass.
Furthermore, the computation is only called on the parents/child of the triggering element, and not on every element of the diagram like it previously was.

### Validation
I used the following diagram to compare both approaches :

![DiagramBefore](https://user-images.githubusercontent.com/61457677/76500251-81684400-6440-11ea-8a3e-9393a3a16ce3.PNG)

I then followed this scenario on this diagram : 

1. Change name of PC 1 to PC 12
2. Change PC1.2 mass to 50
3. Change PC 12 mass to 10
4. Create PC 1.5.1.1, child of PC 1.5.1
5. Create PC 1.3.1, child of PC 1.3
6. Add mass to PC 1.5.1.1
7. Add mass to PC 1.3.1
8. Change PC 1.5.1.1 mass to 10
9. Change PC 1.3.1 mass to 10

To obtain this one : 
![DiagramAfterManip2](https://user-images.githubusercontent.com/61457677/76500656-37cc2900-6441-11ea-8efc-5f495116a9a3.PNG)

I used [Yourkit](https://www.yourkit.com/) to compare how many times both approaches were calling the computeMass method : 
1. With the computation being triggered directly from the odesign, the method was called 276 times : 
![image](https://user-images.githubusercontent.com/61457677/76501315-554dc280-6442-11ea-880d-2feab640f03d.png)
2. With the computation being triggered by the listener approach, the method was called 24 times : 
![image](https://user-images.githubusercontent.com/61457677/76501623-e6249e00-6442-11ea-9c4d-3692dd3c980c.png)

I also added a new build profile that lauches a JUnit test suite. This test suite contains 9 test cases to check that the mass of the elements of the diagram are correctly computed during the following scenarios : 
1. Opening a new session
2. Adding a new mass to the model
3. Removing a mass from the model
4. Editing a mass from the model 




